### PR TITLE
build-step for flow types

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,6 @@
 {
   "stage": 0,
-  "loose": "all"
+  "loose": "all",
+  "plugins": ["flow-comments"],
+  "blacklist": ["flow"]
 }

--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ examples/todomvc/webpack.config.js
 examples/counter/node_modules
 examples/counter/server.js
 examples/counter/webpack.config.js
+dist/*

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,7 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel-core": "5.6.15",
     "babel-eslint": "^3.1.15",
     "babel-loader": "^5.1.4",
+    "babel-plugin-flow-comments": "^1.0.9",
     "eslint": "^0.23",
     "eslint-config-airbnb": "0.0.6",
     "eslint-plugin-react": "^2.3.0",


### PR DESCRIPTION
In case you do decide to add flow types, this adds the build steps needed to keep in the flow types in the built files.

Using a babel plug-in flow types are turned in to flow comments, which are still parsed by flow.

The one downside to that currently, is that some type information from ES6 classes is lost. There may be a way around this problem, however.

Leaving this PR here for a future decision.