### PR TITLE
add edit link to the gitbook docs

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,5 +1,13 @@
 {
-	"structure": {
-  	"summary": "docs/README.md"
-	}
+  "gitbook": "2.2.0",
+  "structure": {
+    "summary": "docs/README.md"
+  },
+  "plugins": ["edit-link"],
+  "pluginsConfig": {
+    "edit-link": {
+      "base": "https://github.com/gaearon/redux/tree/master",
+      "label": "Edit This Page"
+    }
+  }
 }


### PR DESCRIPTION
RE: #345 

to install the plugin you need to run:
`gitbook install`

it runs whatever is in `book.json`, so now the Gitbook version can also be specified in there