### PR TITLE
Fix variable name in middleware docs example

### DIFF
--- a/docs/advanced/Middleware.md
+++ b/docs/advanced/Middleware.md
@@ -490,7 +490,7 @@ let createStoreWithMiddleware = applyMiddleware(
   vanillaPromise,
   readyStatePromise,
   logger,
-  errorHandler
+  crashReporter
 )(createStore);
 let todoApp = combineReducers(reducers);
 let store = createStoreWithMiddleware(todoApp);


### PR DESCRIPTION
errorHandler was never created, but crashReporter was created but unused.