### PR TITLE
Add redux-requests to Ecosystem.md

### DIFF
--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -18,6 +18,7 @@ On this page we will only feature a few of them that the Redux maintainers have 
 * [redux-rx](https://github.com/acdlite/redux-rx) — RxJS utilities for Redux, including a middleware for Observable
 * [redux-batched-updates](https://github.com/acdlite/redux-batched-updates) — Batch React updates that occur as a result of Redux dispatches
 * [redux-logger](https://github.com/fcomb/redux-logger) — Log every Redux action and the next state
+* [redux-requests](https://github.com/idolize/redux-requests) — Avoid issuing duplicate HTTP requests
 
 ## Utilities
 


### PR DESCRIPTION
[redux-requests](https://github.com/idolize/redux-requests) is a small Redux middleware and reducer I wrote to help avoid the problem of issuing duplicate HTTP requests.

#### Inspiration

I was inspired by using [Marty's fetch API](http://martyjs.org/guides/fetching-state/index.html) (in that it avoids duplicate HTTP requests), although I was not very satisfied with Marty's approach. Mainly: the Marty fetch API conflates to separate issues:

1. Avoiding duplicate HTTP requests
2. Checking local cache

Mart's fetch API uses the "`id`" to avoid duplicate requests (similar to the "`meta.httpRequest.url`" here), but it also has all that `locally()` `remotely()` stuff to try and manage the local cache, and unfortunately [does not give a lot of control over invalidating the cache](https://github.com/martyjs/marty/issues/354).

#### Why add it to the Ecosystem section?

I want this library to be very simple, and do one thing and one thing well (local cache management should be left up to the developer). And I think managing HTTP requests is a very common requirement for Redux developers.
