### PR TITLE
compatible run scripts for Win/NodeJS, and separate build/test examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
 script:
   - npm test
   - npm run build:examples
-
+  - npm run test:examples

--- a/examples/testAll.js
+++ b/examples/testAll.js
@@ -12,8 +12,7 @@ var exampleDirs = fs.readdirSync(__dirname).filter((file) => {
 
 // Ordering is important here. `npm install` must come first.
 var cmdArgs = [
-  { cmd: 'npm', args: ['install'] },
-  { cmd: 'webpack', args: ['index.js'] }
+  { cmd: 'npm', args: ['test'] }
 ];
 
 for (let dir of exampleDirs) {
@@ -24,6 +23,7 @@ for (let dir of exampleDirs) {
       cwd: path.join(__dirname, dir),
       stdio: 'inherit'
     };
+
     let result = {};
     if (process.platform === 'win32') {
       result = spawnSync(cmdArg.cmd + '.cmd', cmdArg.args, opts);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "mocha --compilers js:babel/register --recursive",
     "test:watch": "npm test -- --watch",
     "test:cov": "babel-node $(npm bin)/isparta cover $(npm bin)/_mocha -- --recursive",
+    "test:examples": "babel-node examples/testAll.js",
     "check": "npm run lint && npm run test",
     "build:lib": "babel src --out-dir lib",
     "build:umd": "webpack src/index.js dist/redux.js --config webpack.config.development.js",


### PR DESCRIPTION
This allows building examples with **Node 12.x** in windows.  
Also separates into "test:examples", and "build:examples" scripts

This leaves just running the tests exclusive to **io.js** due to **jsdom 4** dependency.