### PR TITLE
Docs typo: expore -> explore

### DIFF
--- a/docs/basics/Reducers.md
+++ b/docs/basics/Reducers.md
@@ -392,4 +392,4 @@ export default todoApp;
 
 ## Next Steps
 
-Next, we’ll expore how to [create a Redux store](Store.md) that holds the state and takes care of calling your reducer when you dispatch an action.
+Next, we’ll explore how to [create a Redux store](Store.md) that holds the state and takes care of calling your reducer when you dispatch an action.


### PR DESCRIPTION
The word explore was misspelled as "expore".


Fix the typo :smile:

This is indeed a one-character PR, but I'll add in any more typos if I find them. Loving the new docs btw. Congrats on 1.0.