### PR TITLE
fix `process is not defined` in react-native

### DIFF
--- a/src/utils/combineReducers.js
+++ b/src/utils/combineReducers.js
@@ -105,9 +105,20 @@ export default function combineReducers(reducers) {
       return newState;
     });
 
-    if (process.env.NODE_ENV !== 'production' && !stateShapeVerified) {
-      verifyStateShape(state, finalState);
-      stateShapeVerified = true;
+    if ((
+      // Node-like CommonJS environments (Browserify, Webpack)
+      typeof process !== 'undefined' &&
+      typeof process.env !== 'undefined' &&
+      process.env.NODE_ENV !== 'production'
+    ) ||
+      // React Native
+      typeof __DEV__ !== 'undefined' &&
+      __DEV__ //eslint-disable-line no-undef
+    ) {
+      if (!stateShapeVerified) {
+        verifyStateShape(state, finalState);
+        stateShapeVerified = true;
+      }
     }
 
     return finalState;


### PR DESCRIPTION
`process` doesn't exist in react-native's JavaScriptCore environment, so we should do something like react-redux connect does now.

https://github.com/gaearon/react-redux/blob/master/src/components/createConnect.js#L192