### PR TITLE
Changed below to above in docs/api/README.md

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -23,7 +23,7 @@ This section documents the complete Redux API. Keep in mind that Redux is only c
 
 ### Importing
 
-Every function described below is a top-level export. You can import any of them like this:
+Every function described above is a top-level export. You can import any of them like this:
 
 #### ES6
 


### PR DESCRIPTION
Not quite sure that this is correct but it do make more sense to me.

Changed `below` to `above` in `Every function described below is a top-level export. You can import any of them like this:`