### PR TITLE
Pass store as prop to Root component in real-world example

### DIFF
--- a/examples/real-world/containers/Root.js
+++ b/examples/real-world/containers/Root.js
@@ -1,18 +1,15 @@
 import React, { Component } from 'react';
 import { Provider } from 'react-redux';
 import { Router, Route } from 'react-router';
-import configureStore from '../store/configureStore';
 import App from './App';
 import UserPage from './UserPage';
 import RepoPage from './RepoPage';
-
-const store = configureStore();
 
 export default class Root extends Component {
   render() {
     return (
       <div>
-        <Provider store={store}>
+        <Provider store={this.props.store}>
           {() =>
             <Router history={this.props.history}>
               <Route path='/' component={App}>

--- a/examples/real-world/index.js
+++ b/examples/real-world/index.js
@@ -2,8 +2,11 @@ import 'babel-core/polyfill';
 import React from 'react';
 import Root from './containers/Root';
 import BrowserHistory from 'react-router/lib/BrowserHistory';
+import configureStore from '../store/configureStore';
+
+const store = configureStore();
 
 React.render(
-  <Root history={new BrowserHistory()} />,
+  <Root history={new BrowserHistory()} store={store} />,
   document.getElementById('root')
 );


### PR DESCRIPTION
The advantage of passing the store in from the top level is essentially the same as the advantage of passing the History object in from the top level:

It makes it easier to re-use the Root component in a universal app.