### PR TITLE
README: added link for offline docs & instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ This architecture might seem like an overkill for a counter app, but the beauty 
 * [Glossary](http://rackt.github.io/redux/docs/Glossary.html)
 * [API Reference](http://rackt.github.io/redux/docs/api/index.html)
 
+For PDF, ePub, and MOBI exports for offline reading, and instructions on how to create them, please see: [paulwittmann/redux-offline-docs](https://github.com/paulwittmann/redux-offline-docs).
+
 ### Examples
 
 * [Counter](http://rackt.github.io/redux/docs/introduction/Examples.html#counter) ([source](https://github.com/rackt/redux/tree/master/examples/counter))


### PR DESCRIPTION
**Problem this solves**
+ I want to be able to read the docs on the train / when offline.

**How**
+ link to a repository with instructions on how to create offline docs and example exports (will not always be up-to-date).

**Why this way**
+ don't want to bloat this repo with PDF, mobi, ePub builds. We could add the build instructions in Redux's README.

**Ideas for an even better solution**
+ integrate links to up-to-date PDF, ePub & MOBI files into https://rackt.github.io/redux - didn't hear back from @gitbookIO how that's possible / whether it's in the works.
Mockup:
![mockup](https://cloud.githubusercontent.com/assets/2906365/2809602/8243b7fc-cd78-11e3-8a5d-a4f48b111082.png)
+ add cache manifest to gitbook - didn't hear back from @gitbookIO or @samypesse about why this doesn't seem to be present anymore!? [https://github.com/GitbookIO/gitbook/pull/171](https://github.com/GitbookIO/gitbook/pull/171)