### PR TITLE
Add semicolon for consistency

### DIFF
--- a/docs/introduction/ThreePrinciples.md
+++ b/docs/introduction/ThreePrinciples.md
@@ -71,7 +71,7 @@ function todos(state = [], action) {
         completed: true
       }),
       ...state.slice(action.index + 1)
-    ]
+    ];
   default:
     return state;
   }


### PR DESCRIPTION
It looks like semicolons are not being avoided elsewhere, so I assume this was an accidental omission.