### PR TITLE
Proposal: API for explicit side effects

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -1,4 +1,5 @@
 import isPlainObject from './utils/isPlainObject';
+import { StateAndEffect } from './utils/sideEffects';
 
 /**
  * These are private action types reserved by Redux.
@@ -101,6 +102,15 @@ export default function createStore(reducer, initialState) {
     try {
       isDispatching = true;
       currentState = currentReducer(currentState, action);
+
+      if(currentState instanceof StateAndEffect) {
+        var effect = currentState.effect;
+        // Since side effects may dispatch at any time, don't run them
+        // immediately since we don't want cascading dispatches
+        setTimeout(() => effect(dispatch, getState), 0);
+
+        currentState = currentState.state;
+      }
     } finally {
       isDispatching = false;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,13 @@ import combineReducers from './utils/combineReducers';
 import bindActionCreators from './utils/bindActionCreators';
 import applyMiddleware from './utils/applyMiddleware';
 import compose from './utils/compose';
+import { withSideEffect } from './utils/sideEffects';
 
 export {
   createStore,
   combineReducers,
   bindActionCreators,
   applyMiddleware,
-  compose
+  compose,
+  withSideEffect
 };

--- a/src/utils/sideEffects.js
+++ b/src/utils/sideEffects.js
@@ -1,0 +1,15 @@
+
+export function StateAndEffect(state, effect) {
+  this.effect = effect;
+  this.state = state;
+}
+
+export function withSideEffect(state, effect) {
+  if(state instanceof StateAndEffect) {
+    return new StateAndEffect(state.state, function() {
+      state.effect.apply(null, arguments);
+      effect.apply(null, arguments);
+    });
+  }
+  return new StateAndEffect(state, effect);
+}


### PR DESCRIPTION
*Note: this PR should not be merged, it's just here for discussion and will require improvements*

I've been porting some of the Firefox devtools code to use a redux-like architecture (not actually Redux yet because we need to clean stuff up first), and it's been interesting to try to implement complex use cases. Porting my blog to redux has also helped gain insight on where we can do better.

I used to think that it was really nice and clean for **all** async work to only happen in action creators, using something like the thunk middleware. It is neat to consolidate complex workflows there, and reducers stay pure and synchronous. But there are a few downsides:

* You frequently want to do things that heavily depend on the shape of the state, like caching. See here in my blog: https://github.com/jlongster/blog/blob/e9224e6113399ca6f26f4a0eb1360b4df37e26fa/src/actions/blog.js#L26. The logic for caching it split apart in two places: one where it sets the cache and the other where it checks it. That's not too bad though.
* You also want to do more complex things like control the asynchronous flow: batching requests, forcing specific order of network calls, etc. You actually can't do this at all with async action creators, because this inherently requires the ability to read the flow of actions being dispatched and perform side effects.

I've seen [redux-remotes](https://github.com/rt2zz/redux-remotes) which aims to solve this as well. It allows you do read from the stream of actions and perform async calls based on them, and you have access to `dispatch` and `getState` like in an action creator. But I don't like that it introduces *another* primitive, when we already have action creators and reducers.

There's also #307 and other issues, and I'm sure there will be lots of opinions about this.

@gaearon has been tweeting about Elm recently, and he's right: Elm has been leading the pack here, and it'd be good to follow it's steps. In Elm, you do something that up until now we've been preaching against: reducers can have "side effects", which essentially are just async work. At this point I'm ready to just give up and embrace side effects in reducers.

This PR adds the ability for reducers to return side effects, which are just functions that have access to `dispatch` and `getState` (like async action creators).

**Example:**

```js
const initialState = {
  itemsById: {}
};

function items(state = initialState, action) {
  switch(action.type) {
  case constants.FETCH_ITEM:
    return withSideEffect(state, dispatch => {
      dispatch({
        type: constants.FETCHING_ITEM,
        status: 'begin'
      });

      setTimeout(() => {
        dispatch({
          type: constants.FETCHING_ITEM,
          status: 'success',
        });
      }, 1000);
    })
  case constants.FETCHING_ITEM:
    if(action.status === 'success') {
      const item = action.value;
      return {
        itemsById: Object.assign({}, state.itemsById, { [item.id]: item })
      };
    }
  default:
    return state;
  }
}
```

This works by using `withSideEffect` to return a state object and a side effect. You are free to run this side effect or not. In the normal scenario, side effects are run after the reducers are run in `dispatch`. But if you were replaying actions, you would simply ignore the side effects.

We don't have a type system like Elm, but we can **take advantage** of our dynamic typing by returning a class instance so that we can internally check it. I added an internal `StateAndEffect` class, and check if that is returned, and if true I know side effects are returned. It doesn't matter that this is a class instance because we *never* care about serializing side effects.

It's basically a monadic operation but I decided against the terms "lift" and "unlift".

## Higher Order Reducers

We could apply the higher-order concept here too, if you want to separate pure reducers and reducers with side effects:

```js

// items.js
const initialState = {
  itemsById: {}
};

function items(state = initialState, action) {
  switch(action.type) {
  case constants.FETCHING_ITEM:
    if(action.status === 'success') {
      const item = action.value;
      return {
        itemsById: Object.assign({}, state.itemsById, { [item.id]: item })
      };
    }
  default:
    return state;
  }
}

// itemFetcher.js
const items = require('./items');

function itemFetcher(reducer) {
  return (state, action) => {
    switch(action.type) {
    case constants.FETCH_ITEM:
      // We still call the lower reducer, but we don't really have to
      // in this scenario
      return withSideEffect(reducer(state, action), dispatch => {
        dispatch({
          type: constants.FETCHING_ITEM,
          status: 'begin'
        });

        setTimeout(() => {
          dispatch({
            type: constants.FETCHING_ITEM,
            status: 'success',
          });
        }, 1000);
      });
    default:
      // On the init action, this *should* pass undefined as state so
      // it still gets the correct initialState, right?
      return reducer(state, action);
    }
  }
}

// One problem here though is that this will be attached to the state as `state.itemFetcher`,
// not `state.items` but I'm sure that's solvable
module.exports = itemFetcher(items);
```

`withSideEffect` is monadic: if passed another `StateAndEffect` type is will correctly compose the state and effect into a new `StateAndEffect` type. When the side effects run, both the effects from this reducer and any lower reducer will run.

## Advanced Example: Ordering Requests

Here's an example of something you can't do with async action creators. Say you want to do an HTTP request because an action comes through. That's fine. But if the user wants to initiate multiple of these requests, you want to make *sure* that only one happens at a time. Additionally, for simplicity, if multiple come through before the first finishes, we just do an additional **single** request after the first one finishes (we don't run 5 in order if 5 comes through at once, we run 1 to completion and then run an addition 1 request).

Demo here: http://jlongster.github.io/redux-experiments/side-effects/
Code here: https://github.com/jlongster/redux-experiments/tree/master/side-effects

The neat part is that we can use the sequence of actions to control what actual side effects happen, and I can extract this functionality out into a single library. Let's call it `ensureCompleted`:

```js
const { withSideEffect } = require('redux');

function ensureCompleted(initialState, fetchActionType, statusActionType, reducer) {
  // This could be more complex, of course, just keeping it simple for
  // a demo
  let queued = false;
  let fetching = false;

  return (state = initialState, action) => {
    switch(action.type) {
    case fetchActionType:
      if(fetching) {
        queued = true;
        return state;
      }
      fetching = true;
      return reducer(state, action);

    case statusActionType:
      if(action.status === 'success') {
        if(queued) {
          queued = false;
          fetching = false;
          return withSideEffect(reducer(state, action), dispatch => {
            dispatch({ type: fetchActionType });
          });
        }
        else {
          fetching = false;
        }
      }
    }

    return reducer(state, action);
  }
}

module.exports = ensureCompleted;
```

This is a higher-order reducer, and wraps the item fetcher reducer here: https://github.com/jlongster/redux-experiments/blob/master/side-effects/reducers/items.js#L50. The item fetcher reducer simply does the async call blindly, unknowing that it's actually being batched/reordered/whatever.

## Questions

* Does this mess up any higher-order stores or middleware? Only anything dealing with what comes back from a reducer needs to know about this, and I don't think this will break any libs.

* I'm still not sure about composition of effects. Higher-order reducers are neat, but they mess up how we currently combine reducers. The name of the higher-order reducer will be used as the name of the piece of state, when you probably want it to be something else (the "dumb" reducer). Elm takes quite a different approach to composing state it seems. "Reducers" are just simple models that can be composed: https://github.com/evancz/elm-architecture-tutorial/#example-6-pair-of-random-gif-viewers.

For example, let's say I have a reducer that fetches blog posts and stores them. I fetch a blog post with an id of `foo`. But the blog post also has a "readnext" property which is the id of the next blog post to read, and I need to fetch that after I get `foo`. In normal async world I'd do something like this:

```js
let post = yield getPost('foo');
let readnext = null;
if(post.readnext) {
  readnext = yield getPost(post.readnext);
}
```

I'd love to figure out how to fit all of this into something that doesn't obfuscate the async workflow too much.

* Currently I run side effects on the next turn of the event loop (after calling the reducer) because it could immediately dispatch, and you don't want cascading dispatches. This feels a little weird, but I don't know if that's an indication that this is the wrong path or there's a better fix for that.

This is a bit of a braindump, I hope it isn't too confusing. I didn't spend much time gently introducing these concepts, so if you are confused, check out this Elm tutorial first: https://github.com/evancz/elm-architecture-tutorial/. Let me know what you think. Or if I'm horribly, horribly wrong.