### PR TITLE
Changing import 'babel' typo to import 'babel-core'

### DIFF
--- a/examples/todomvc/index.js
+++ b/examples/todomvc/index.js
@@ -1,4 +1,4 @@
-import 'babel/polyfill';
+import 'babel-core/polyfill';
 
 import React from 'react';
 import Root from './containers/Root';


### PR DESCRIPTION
There was slight typo in todomvc example. There is no package named 'babel', it should be 'babel-core'.