### PR TITLE
removed resolve to src

### DIFF
--- a/examples/todomvc/webpack.config.js
+++ b/examples/todomvc/webpack.config.js
@@ -17,12 +17,6 @@ module.exports = {
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin()
   ],
-  resolve: {
-    alias: {
-      'redux': path.join(__dirname, '..', '..', 'src')
-    },
-    extensions: ['', '.js']
-  },
   module: {
     loaders: [{
       test: /\.js$/,


### PR DESCRIPTION
Looks like someone was reading the redux libs from a local `src` dir, which does not exist. `npm install` and running the app now works.