### PR TITLE
Fixes link to elm architecture tutorial

### DIFF
--- a/docs/introduction/PriorArt.md
+++ b/docs/introduction/PriorArt.md
@@ -19,7 +19,7 @@ While it is technically *possible* to [write impure reducers](https://github.com
 
 ### Elm
 
-[Elm](http://elm-lang.org/) is a functional programming language inspired by Haskell created by [Evan Czaplicki](https://twitter.com/czaplic). It enforces [a “model view update” architecture](http://elm-lang.org/guide/architecture), where the update has the following signature: `(state, action) => state`. Technically, Elm “updaters” are equivalent to the reducers in Redux.
+[Elm](http://elm-lang.org/) is a functional programming language inspired by Haskell created by [Evan Czaplicki](https://twitter.com/czaplic). It enforces [a “model view update” architecture](https://github.com/evancz/elm-architecture-tutorial/), where the update has the following signature: `(state, action) => state`. Technically, Elm “updaters” are equivalent to the reducers in Redux.
 
 But unlike Redux, Elm is a language, so it is able to benefit from many things like enforced purity, static typing, out of the box immutability, and pattern matching (using the `case` expression). Even if you don’t plan to use Elm, you should read about the Elm architecture, and play with it. There is an interesting [JavaScript library playground implementing similar ideas](https://github.com/paldepind/noname-functional-frontend-framework). We should look there for inspiration on Redux! One way that we can get closer to the static typing of Elm is by [using a gradual typing solution like Flow](https://github.com/rackt/redux/issues/290).
 


### PR DESCRIPTION
[Existing link 404s](http://elm-lang.org/guide/architecture), the file was [removed](https://github.com/elm-lang/elm-lang.org/commit/039fd9eba4f876453eec5ba032e51fbaf39c7c53). 

elm-lang.org directly links to the elm-architecture-tutorial repo now, so I switched the link over to that