### PR TITLE
Fixed broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ I wrote Redux while working on my React Europe talk called [“Hot Reloading wit
 
 ### Influences
 
-Redux evolves the ideas of [Flux](https://facebook.github.io/flux), but avoids its complexity by taking cues from [Elm](http://elm-lang.org/guide/architecture).  
+Redux evolves the ideas of [Flux](https://facebook.github.io/flux), but avoids its complexity by taking cues from [Elm](https://github.com/evancz/elm-architecture-tutorial/).  
 Whether you have used them or not, Redux takes a few minutes to get started with.
 
 ### Installation


### PR DESCRIPTION
Does what https://github.com/rackt/redux/pull/575 did but in README.md.
