### PR TITLE
Don't recommend the use of `import * as reducers`.

### DIFF
--- a/docs/api/combineReducers.md
+++ b/docs/api/combineReducers.md
@@ -82,13 +82,7 @@ export default combineReducers({
 
 ```js
 import { createStore, combineReducers } from 'redux';
-
 import reducer from './reducers/index';
-console.log(reducers);
-// {
-//   todos: Function,
-//   counter: Function
-// }
 
 let store = createStore(reducer);
 console.log(store.getState());

--- a/docs/api/combineReducers.md
+++ b/docs/api/combineReducers.md
@@ -15,7 +15,7 @@ The resulting reducer calls every child reducer, and gather their results into a
 
 1. `reducers` (*Object*): An object whose values correspond to different reducing functions that need to be combined into one. See the notes below for some rules every passed reducer must follow.
 
-> Earlier documentation suggested the use of the ES6 `import * as reducers` syntax to obtain the reducers object. This was the source of a lot of confusion, which is why we now recommend the use of `reducers/index.js` with a call to combineReducers.
+> Earlier documentation suggested the use of the ES6 `import * as reducers` syntax to obtain the reducers object. This was the source of a lot of confusion, which is why we now recommend exporting a single reducer obtained using `combineReducers()` from `reducers/index.js` instead. An example is included below.
 
 #### Returns
 
@@ -36,19 +36,6 @@ Any reducer passed to `combineReducers` must satisfy these rules:
 While `combineReducers` attempts to check that your reducers conform to some of these rules, you should remember them, and do your best to follow them.
 
 #### Example
-
-#### `reducers/index.js`
-
-```js
-import { combineReducers } from 'redux';
-import todos from './todos';
-import counter from './counter';
-
-export default combineReducers({
-  todos,
-  counter
-});
-```
 
 #### `reducers/todos.js`
 
@@ -76,6 +63,19 @@ export default function counter(state = 0, action) {
     return state;
   }
 }
+```
+
+#### `reducers/index.js`
+
+```js
+import { combineReducers } from 'redux';
+import todos from './todos';
+import counter from './counter';
+
+export default combineReducers({
+  todos,
+  counter
+});
 ```
 
 #### `App.js`

--- a/docs/api/combineReducers.md
+++ b/docs/api/combineReducers.md
@@ -7,13 +7,15 @@ reducing function you can pass to [`createStore`](createStore.md).
 
 The resulting reducer calls every child reducer, and gather their results into a single state object. The shape of the state object matches the keys of the passed `reducers`.
 
->##### A Note for Flux Users
+> ##### A Note for Flux Users
 
->This function helps you organize your reducers to manage their own slices of state, similar to how you would have different Flux Stores to manage different state. With Redux, there is just one store, but `combineReducers` helps you keep the same logical division between reducers.
+> This function helps you organize your reducers to manage their own slices of state, similar to how you would have different Flux Stores to manage different state. With Redux, there is just one store, but `combineReducers` helps you keep the same logical division between reducers.
 
 #### Arguments
 
-1. `reducers` (*Object*): An object whose values correspond to different reducing functions that need to be combined into one. One handy way to obtain it is to use ES6 `import * as reducers` syntax, but you can also construct this object manually. See the notes below for some rules every passed reducer must follow.
+1. `reducers` (*Object*): An object whose values correspond to different reducing functions that need to be combined into one. See the notes below for some rules every passed reducer must follow.
+
+> Earlier documentation suggested the use of the ES6 `import * as reducers` syntax to obtain the reducers object. This was the source of a lot of confusion, which is why we now recommend the use of `reducers/index.js` with a call to combineReducers.
 
 #### Returns
 
@@ -35,10 +37,23 @@ While `combineReducers` attempts to check that your reducers conform to some of 
 
 #### Example
 
-#### `reducers.js`
+#### `reducers/index.js`
 
 ```js
-export function todos(state = [], action) {
+import { combineReducers } from 'redux';
+import todos from './todos';
+import counter from './counter';
+
+export default combineReducers({
+  todos,
+  counter
+});
+```
+
+#### `reducers/todos.js`
+
+```js
+export default function todos(state = [], action) {
   switch (action.type) {
   case 'ADD_TODO':
     return state.concat([action.text]);
@@ -46,8 +61,12 @@ export function todos(state = [], action) {
     return state;
   }
 }
+```
 
-export function counter(state = 0, action) {
+#### `reducers/counter.js`
+
+```js
+export default function counter(state = 0, action) {
   switch (action.type) {
   case 'INCREMENT':
     return state + 1;
@@ -64,14 +83,13 @@ export function counter(state = 0, action) {
 ```js
 import { createStore, combineReducers } from 'redux';
 
-import * as reducers from './reducers';
+import reducer from './reducers/index';
 console.log(reducers);
 // {
 //   todos: Function,
 //   counter: Function
 // }
 
-let reducer = combineReducers(reducers);
 let store = createStore(reducer);
 console.log(store.getState());
 // {


### PR DESCRIPTION
Replaced the suggestion to use `import * as reducers` with the recommendation to use `reducers/index.js` and call `combineReducers` there. Updated the code examples accordingly.

As discussed here: https://github.com/rackt/redux/pull/473