### PR TITLE
API change proposal: listener() --> listener(action)

### DIFF
--- a/docs/api/Store.md
+++ b/docs/api/Store.md
@@ -89,7 +89,7 @@ To unsubscribe the change listener, invoke the function returned by `subscribe`.
 
 #### Arguments
 
-1. `listener` (*Function*): The callback to be invoked any time an action has been dispatched, and the state tree might have changed. You may call [`getState()`](#getState) inside this callback to read the current state tree. It is reasonable to expect that the store’s reducer is a pure function, so you may compare references to some deep path in the state tree to learn whether its value has changed.
+1. `listener(action)` (*Function*): The callback to be invoked any time an action has been dispatched, and the state tree might have changed. You may call [`getState()`](#getState) inside this callback to read the current state tree. It is reasonable to expect that the store’s reducer is a pure function, so you may compare references to some deep path in the state tree to learn whether its value has changed.
 
 ##### Returns
 

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -105,7 +105,7 @@ export default function createStore(reducer, initialState) {
       isDispatching = false;
     }
 
-    listeners.slice().forEach(listener => listener());
+    listeners.slice().forEach(listener => listener(action));
     return action;
   }
 

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -237,6 +237,20 @@ describe('createStore', () => {
     });
     store.dispatch(addTodo('Hello'));
   });
+  
+  it('should pass the correct action to subscribers', done => {
+    const store = createStore(reducers.todos);
+    const stop = 100;
+    let i = 0;
+    store.subscribe(action => {
+      expect(action.text).toEqual(i);
+      i++;
+      if (i === stop) done();
+    });
+    for (let j = 0; j < stop; j++) {
+      store.dispatch(addTodo(j));
+    }
+  });
 
   it('should only accept plain object actions', () => {
     const store = createStore(reducers.todos);


### PR DESCRIPTION
Hi,

As our Redux project grows at our company, we have found useful to get the last dispatched action at the beginning of a `store.subscribe` like this:
```javascript
store.subscribe(() => {
    const { records } = store.getState(); // a reducer that holds every action ever dispatched
    const lastAction = records[records.length - 1];
```
But that approach is not reliable every time: if we wait too long before accessing `records[records.length - 1]` we might end up with another action dispatched in the meanwhile.

So we thought, in `createStore.js`, what about calling `listener` with the dispatched action as argument ?
```javascript
listeners.slice().forEach(listener => listener(action));
```
That would allow developers to use `store.subscribe()` as a way to create action-based side-effects, thus making Redux even more flexible.

Would anyone else like this ?

Thanks for the lib.