### PR TITLE
(Do not merge!) Remove getReducer and replaceReducer from public API

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -109,34 +109,6 @@ export default function createStore(reducer, initialState) {
     return action;
   }
 
-  /**
-   * Returns the reducer currently used by the store to calculate the state.
-   *
-   * It is likely that you will only need this function if you implement a hot
-   * reloading mechanism for Redux.
-   *
-   * @returns {Function} The reducer used by the current store.
-   */
-  function getReducer() {
-    return currentReducer;
-  }
-
-  /**
-   * Replaces the reducer currently used by the store to calculate the state.
-   *
-   * You might need this if your app implements code splitting and you want to
-   * load some of the reducers dynamically. You might also need this if you
-   * implement a hot reloading mechanism for Redux.
-   *
-   * @param {Function} nextReducer The reducer for the store to use instead.
-   * @returns {void}
-   */
-  function replaceReducer(nextReducer) {
-    currentReducer = nextReducer;
-    dispatch({ type: ActionTypes.INIT });
-  }
-
-
   // When a store is created, an "INIT" action is dispatched so that every
   // reducer returns their initial state. This effectively populates
   // the initial state tree.
@@ -145,8 +117,6 @@ export default function createStore(reducer, initialState) {
   return {
     dispatch,
     subscribe,
-    getState,
-    getReducer,
-    replaceReducer
+    getState
   };
 }

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -8,12 +8,10 @@ describe('createStore', () => {
     const store = createStore(combineReducers(reducers));
     const methods = Object.keys(store);
 
-    expect(methods.length).toBe(5);
+    expect(methods.length).toBe(3);
     expect(methods).toContain('subscribe');
     expect(methods).toContain('dispatch');
     expect(methods).toContain('getState');
-    expect(methods).toContain('getReducer');
-    expect(methods).toContain('replaceReducer');
   });
 
   it('should require a reducer function', () => {
@@ -91,69 +89,6 @@ describe('createStore', () => {
     }, {
       id: 2,
       text: 'World'
-    }]);
-  });
-
-  it('should preserve the state when replacing a reducer', () => {
-    const store = createStore(reducers.todos);
-    store.dispatch(addTodo('Hello'));
-    store.dispatch(addTodo('World'));
-    expect(store.getState()).toEqual([{
-      id: 1,
-      text: 'Hello'
-    }, {
-      id: 2,
-      text: 'World'
-    }]);
-
-    let nextStore = createStore(reducers.todosReverse);
-    store.replaceReducer(nextStore.getReducer());
-    expect(store.getState()).toEqual([{
-      id: 1,
-      text: 'Hello'
-    }, {
-      id: 2,
-      text: 'World'
-    }]);
-
-    store.dispatch(addTodo('Perhaps'));
-    expect(store.getState()).toEqual([{
-      id: 3,
-      text: 'Perhaps'
-    }, {
-      id: 1,
-      text: 'Hello'
-    }, {
-      id: 2,
-      text: 'World'
-    }]);
-
-    nextStore = createStore(reducers.todos);
-    store.replaceReducer(nextStore.getReducer());
-    expect(store.getState()).toEqual([{
-      id: 3,
-      text: 'Perhaps'
-    }, {
-      id: 1,
-      text: 'Hello'
-    }, {
-      id: 2,
-      text: 'World'
-    }]);
-
-    store.dispatch(addTodo('Surely'));
-    expect(store.getState()).toEqual([{
-      id: 3,
-      text: 'Perhaps'
-    }, {
-      id: 1,
-      text: 'Hello'
-    }, {
-      id: 2,
-      text: 'World'
-    }, {
-      id: 4,
-      text: 'Surely'
     }]);
   });
 


### PR DESCRIPTION
As discussed in #350, we want to get rid of them to simplify Store API, and express alternatives to them in userland.