### PR TITLE
Make usernames case insensitive in real-world example

### DIFF
--- a/examples/real-world/containers/UserPage.js
+++ b/examples/real-world/containers/UserPage.js
@@ -82,14 +82,17 @@ function mapStateToProps(state, ownProps) {
   const starredPagination = starredByUser[login] || { ids: [] };
   const starredRepos = starredPagination.ids.map(id => repos[id]);
   const starredRepoOwners = starredRepos.map(repo => users[repo.owner]);
-  const user = users[login.toLowerCase()];
+
+  const lowercaseLogin = login.toLowerCase();
+  const username = Object.keys(users).find(
+    k => k.toLowerCase() === lowercaseLogin);
 
   return {
-    login,
+    login: username || login,
     starredRepos,
     starredRepoOwners,
     starredPagination,
-    user
+    user: users[username],
   };
 }
 

--- a/examples/real-world/containers/UserPage.js
+++ b/examples/real-world/containers/UserPage.js
@@ -82,13 +82,14 @@ function mapStateToProps(state, ownProps) {
   const starredPagination = starredByUser[login] || { ids: [] };
   const starredRepos = starredPagination.ids.map(id => repos[id]);
   const starredRepoOwners = starredRepos.map(repo => users[repo.owner]);
+  const user = users[login.toLowerCase()];
 
   return {
     login,
     starredRepos,
     starredRepoOwners,
     starredPagination,
-    user: users[login]
+    user
   };
 }
 

--- a/examples/real-world/reducers/index.js
+++ b/examples/real-world/reducers/index.js
@@ -1,14 +1,12 @@
 import * as ActionTypes from '../actions';
-import { merge, mapKeys } from 'lodash/object';
+import merge from 'lodash/object/merge';
 import paginate from './paginate';
 import { combineReducers } from 'redux';
 
 // Updates an entity cache in response to any action with response.entities.
 export function entities(state = { users: {}, repos: {} }, action) {
   if (action.response && action.response.entities) {
-    let result = merge({}, state, action.response.entities);
-    result.users = mapKeys(result.users, (v, k) => k.toLowerCase());
-    return result;
+    return merge({}, state, action.response.entities);
   }
 
   return state;

--- a/examples/real-world/reducers/index.js
+++ b/examples/real-world/reducers/index.js
@@ -1,12 +1,14 @@
 import * as ActionTypes from '../actions';
-import merge from 'lodash/object/merge';
+import { merge, mapKeys } from 'lodash/object';
 import paginate from './paginate';
 import { combineReducers } from 'redux';
 
 // Updates an entity cache in response to any action with response.entities.
 export function entities(state = { users: {}, repos: {} }, action) {
   if (action.response && action.response.entities) {
-    return merge({}, state, action.response.entities);
+    let result = merge({}, state, action.response.entities);
+    result.users = mapKeys(result.users, (v, k) => k.toLowerCase());
+    return result;
   }
 
   return state;


### PR DESCRIPTION
GitHub usernames are case insensitive. If you search 'redux' in the real-world example, the screen displays 'Loading redux's profile...' despite the fact that github's api returned a valid object for the username "Redux." This change now keys usernames in their lowercase form.

I discovered this when trying to follow along with the documentation. I'm new to react, redux, etc. so let me know if there is a cleaner way of fixing this!