### PR TITLE
Fix universal rendering example (configureStore vs. createStore)

### DIFF
--- a/examples/universal/client.js
+++ b/examples/universal/client.js
@@ -1,13 +1,12 @@
 import 'babel-core/polyfill';
 import React from 'react';
-import { createStore } from 'redux';
+import configureStore from './store/configureStore';
 import { Provider } from 'react-redux';
 import App from './containers/App';
-import counterApp from './reducers';
 
 const initialState = window.__INITIAL_STATE__;
 
-const store = createStore(counterApp, initialState);
+const store = configureStore(initialState);
 
 const rootElement = document.getElementById('app');
 

--- a/examples/universal/server.js
+++ b/examples/universal/server.js
@@ -2,9 +2,8 @@ import path from 'path';
 import Express from 'express';
 import qs from 'qs';
 import React from 'react';
-import { createStore } from 'redux';
+import configureStore from './store/configureStore';
 import { Provider } from 'react-redux';
-import counterApp from './reducers';
 import App from './containers/App';
 import { fetchCounter } from './api/counter';
 
@@ -30,7 +29,7 @@ function handleRender(req, res) {
     let initialState = { counter };
 
     // Create a new Redux store instance
-    const store = createStore(counterApp, initialState);
+    const store = configureStore(initialState);
 
     // Render the component to a string
     const html = React.renderToString(


### PR DESCRIPTION
The example is using `createStore` in both the server and client script, instead of `store/configureStore.js` with the thunk middleware. Fixed this and now the async and conditional action works.