### PR TITLE
Add universal to examples and update webpack config

### DIFF
--- a/docs/introduction/Examples.md
+++ b/docs/introduction/Examples.md
@@ -64,6 +64,26 @@ It covers:
 * Caching responses and showing a spinner while data is fetching;
 * Invalidating the cached data.
 
+## Universal
+
+Run the [Universal](https://github.com/rackt/redux/tree/master/examples/universal) example:
+
+```
+git clone https://github.com/rackt/redux.git
+
+cd redux/examples/universal
+npm install
+npm start & npm run client
+
+open http://localhost:8080/
+```
+
+It covers:
+
+* [Universal rendering](/docs/recipes/ServerRendering.md) with Redux and React
+* Prefetching state based on input and via asynchronous fetches.
+* Passing state from the server to the client
+
 ## Real World
 
 Run the [Real World](https://github.com/rackt/redux/tree/master/examples/real-world) example:

--- a/examples/universal/webpack.config.js
+++ b/examples/universal/webpack.config.js
@@ -19,22 +19,28 @@ module.exports = {
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin()
   ],
-  resolve: {
-    alias: {
-      'redux': path.join(__dirname, '..', '..', 'src')
-    },
-    extensions: ['', '.js']
-  },
   module: {
     loaders: [{
       test: /\.js$/,
       loaders: ['react-hot', 'babel?optional=runtime'],
       exclude: /node_modules/,
       include: __dirname
-    }, {
-      test: /\.js$/,
-      loaders: ['babel'],
-      include: path.join(__dirname, '..', '..', 'src')
     }]
   }
 };
+
+// When inside Redux repo, prefer src to compiled version.
+// You can safely delete these lines in your project.
+var reduxSrc = path.join(__dirname, '..', '..', 'src');
+var reduxNodeModules = path.join(__dirname, '..', '..', 'node_modules');
+var fs = require('fs');
+if (fs.existsSync(reduxSrc) && fs.existsSync(reduxNodeModules)) {
+  // Resolve Redux to source
+  module.exports.resolve = { alias: { 'redux': reduxSrc } };
+  // Compile Redux from source
+  module.exports.module.loaders.push({
+    test: /\.js$/,
+    loaders: ['babel'],
+    include: reduxSrc
+  });
+}


### PR DESCRIPTION
This is to match the changes in #626, which happened before the universal example was merged, but after I had finished coding it.

Also, it adds the example to the Examples doc.