### PR TITLE
Don't depend on --harmony flag when running 'npm run client'

### DIFF
--- a/examples/universal/webpack.server.js
+++ b/examples/universal/webpack.server.js
@@ -18,5 +18,5 @@ new WebpackDevServer(webpack(config), {
     console.error(err);
   }
 
-  console.info(`==> 🚧  Webpack development server listening on port ${config.devServerPort}`);
+  console.info('==> 🚧  Webpack development server listening on port ' + config.devServerPort);
 });


### PR DESCRIPTION
Removed use of ES6 string interpolation