### PR TITLE
Remove NoErrorsPlugin

### DIFF
--- a/examples/async/package.json
+++ b/examples/async/package.json
@@ -41,7 +41,7 @@
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",
     "node-libs-browser": "^0.5.2",
-    "react-hot-loader": "^1.2.8",
+    "react-hot-loader": "^1.3.0",
     "webpack": "^1.9.11",
     "webpack-dev-server": "^1.9.0"
   }

--- a/examples/async/webpack.config.js
+++ b/examples/async/webpack.config.js
@@ -14,8 +14,7 @@ module.exports = {
     publicPath: '/static/'
   },
   plugins: [
-    new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
+    new webpack.HotModuleReplacementPlugin()
   ],
   module: {
     loaders: [{

--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -30,7 +30,7 @@
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",
     "node-libs-browser": "^0.5.2",
-    "react-hot-loader": "^1.2.7",
+    "react-hot-loader": "^1.3.0",
     "webpack": "^1.9.11",
     "webpack-dev-server": "^1.9.0"
   }

--- a/examples/counter/webpack.config.js
+++ b/examples/counter/webpack.config.js
@@ -14,8 +14,7 @@ module.exports = {
     publicPath: '/static/'
   },
   plugins: [
-    new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
+    new webpack.HotModuleReplacementPlugin()
   ],
   module: {
     loaders: [{

--- a/examples/real-world/package.json
+++ b/examples/real-world/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "babel-core": "^5.6.18",
     "babel-loader": "^5.1.4",
-    "react-hot-loader": "^1.2.7",
+    "react-hot-loader": "^1.3.0",
     "webpack": "^1.9.11",
     "webpack-dev-server": "^1.9.0"
   }

--- a/examples/real-world/webpack.config.js
+++ b/examples/real-world/webpack.config.js
@@ -14,8 +14,7 @@ module.exports = {
     publicPath: '/static/'
   },
   plugins: [
-    new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
+    new webpack.HotModuleReplacementPlugin()
   ],
   module: {
     loaders: [{

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -19,8 +19,8 @@
   "dependencies": {
     "classnames": "^2.1.2",
     "react": "^0.13.3",
-    "react-redux": "^1.0.0",
-    "redux": "^1.0.0-rc"
+    "react-redux": "^1.0.1",
+    "redux": "^1.0.1"
   },
   "devDependencies": {
     "babel-core": "^5.6.18",
@@ -31,7 +31,7 @@
     "mocha-jsdom": "^1.0.0",
     "node-libs-browser": "^0.5.2",
     "raw-loader": "^0.5.1",
-    "react-hot-loader": "^1.2.7",
+    "react-hot-loader": "^1.3.0",
     "style-loader": "^0.12.3",
     "todomvc-app-css": "^2.0.1",
     "webpack": "^1.9.11",

--- a/examples/todomvc/webpack.config.js
+++ b/examples/todomvc/webpack.config.js
@@ -14,8 +14,7 @@ module.exports = {
     publicPath: '/static/'
   },
   plugins: [
-    new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
+    new webpack.HotModuleReplacementPlugin()
   ],
   module: {
     loaders: [{

--- a/examples/universal/package.json
+++ b/examples/universal/package.json
@@ -30,7 +30,7 @@
     "babel-core": "^5.8.22",
     "babel-loader": "^5.3.2",
     "babel-runtime": "^5.8.20",
-    "react-hot-loader": "^1.2.8",
+    "react-hot-loader": "^1.3.0",
     "webpack": "^1.11.0",
     "webpack-dev-server": "^1.10.1"
   }

--- a/examples/universal/webpack.config.js
+++ b/examples/universal/webpack.config.js
@@ -17,8 +17,7 @@ module.exports = {
     publicPath: 'http://' + host + ':' + port + '/dist/'
   },
   plugins: [
-    new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
+    new webpack.HotModuleReplacementPlugin()
   ],
   module: {
     loaders: [{


### PR DESCRIPTION
With React Hot Loader 1.3.0 release, we don't recommend `NoErrorsPlugin` anymore.
The problems it was supposed to fix were actually problems in RHL itself, and are fixed in 1.3.0 with https://github.com/gaearon/react-hot-loader/pull/187.