### PR TITLE
Add store.resetState for reverting to initial state value

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -36,7 +36,7 @@ export default function createStore(reducer, initialState) {
   }
 
   var currentReducer = reducer;
-  var currentState = initialState;
+  var currentState;
   var listeners = [];
   var isDispatching = false;
 
@@ -136,17 +136,27 @@ export default function createStore(reducer, initialState) {
     dispatch({ type: ActionTypes.INIT });
   }
 
+  /**
+   * Resets the state tree to the value after running "INIT"
+   *
+   * @returns {void}
+   */
+  function resetState() {
+    currentState = initialState;
+    dispatch({ type: ActionTypes.INIT });
+  }
 
   // When a store is created, an "INIT" action is dispatched so that every
   // reducer returns their initial state. This effectively populates
   // the initial state tree.
-  dispatch({ type: ActionTypes.INIT });
+  resetState();
 
   return {
     dispatch,
     subscribe,
     getState,
     getReducer,
-    replaceReducer
+    replaceReducer,
+    resetState
   };
 }

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -8,12 +8,13 @@ describe('createStore', () => {
     const store = createStore(combineReducers(reducers));
     const methods = Object.keys(store);
 
-    expect(methods.length).toBe(5);
+    expect(methods.length).toBe(6);
     expect(methods).toContain('subscribe');
     expect(methods).toContain('dispatch');
     expect(methods).toContain('getState');
     expect(methods).toContain('getReducer');
     expect(methods).toContain('replaceReducer');
+    expect(methods).toContain('resetState');
   });
 
   it('should require a reducer function', () => {
@@ -293,5 +294,25 @@ describe('createStore', () => {
     expect(() =>
       store.dispatch({})
     ).toNotThrow();
+  });
+
+  it('can resetState() to initial state value', () => {
+    const store = createStore(reducers.todos);
+    expect(store.getState()).toEqual([]);
+
+    store.dispatch({});
+    expect(store.getState()).toEqual([]);
+
+    store.dispatch(addTodo('Hello'));
+    store.dispatch(addTodo('World'));
+    expect(store.getState()).toEqual([{
+      id: 1,
+      text: 'Hello'
+    }, {
+      id: 2,
+      text: 'World'
+    }]);
+    store.resetState();
+    expect(store.getState()).toEqual([]);
   });
 });


### PR DESCRIPTION
I have a situation where I'd like to reset the entire app state to the original value (after `ActionTypes.INIT` is run), but couldn't find a clean way to write it as a plugin without replacing the majority of `createStore`.

I can also imagine situations where you'd want to replace the entire `currentState` with a new value, for example if you wanted to re-hydrate the entire app state from a different serialized session.

So I wanted to see if this `resetState` or an alternate more generic `replaceState` seemed like a good enough use case to add to the core API. The `replaceState` would look similar to this PR, but would pass in the state value and then run the init dispatch:

```js
/**
 * Replaces the state tree with a new value and runs "INIT"
 *
 * @returns {void}
 */
function replaceState(newState) {
  currentState = newState;
  dispatch({ type: ActionTypes.INIT });
}


// When a store is created, an "INIT" action is dispatched so that every
// reducer returns their initial state. This effectively populates
// the initial state tree.
replaceState(initialState);
```