### PR TITLE
Alternative to #658

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -36,7 +36,7 @@ export default function createStore(reducer, initialState) {
   }
 
   var currentReducer = reducer;
-  var currentState = initialState;
+  var currentState;
   var listeners = [];
   var isDispatching = false;
 
@@ -136,17 +136,28 @@ export default function createStore(reducer, initialState) {
     dispatch({ type: ActionTypes.INIT });
   }
 
+  /**
+   * Resets the state tree, if no value is provided, defaults to the initialState
+   * provided to the reducer.
+   *
+   * @returns {void}
+   */
+  function resetState(newState = initialState) {
+    currentState = newState;
+    dispatch({ type: ActionTypes.INIT });
+  }
 
   // When a store is created, an "INIT" action is dispatched so that every
   // reducer returns their initial state. This effectively populates
   // the initial state tree.
-  dispatch({ type: ActionTypes.INIT });
+  resetState();
 
   return {
     dispatch,
     subscribe,
     getState,
     getReducer,
-    replaceReducer
+    replaceReducer,
+    resetState
   };
 }

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -8,12 +8,13 @@ describe('createStore', () => {
     const store = createStore(combineReducers(reducers));
     const methods = Object.keys(store);
 
-    expect(methods.length).toBe(5);
+    expect(methods.length).toBe(6);
     expect(methods).toContain('subscribe');
     expect(methods).toContain('dispatch');
     expect(methods).toContain('getState');
     expect(methods).toContain('getReducer');
     expect(methods).toContain('replaceReducer');
+    expect(methods).toContain('resetState');
   });
 
   it('should require a reducer function', () => {
@@ -293,5 +294,39 @@ describe('createStore', () => {
     expect(() =>
       store.dispatch({})
     ).toNotThrow();
+  });
+
+  it('can resetState to initial state value', () => {
+    const store = createStore(reducers.todos);
+    expect(store.getState()).toEqual([]);
+
+    store.dispatch({});
+    expect(store.getState()).toEqual([]);
+
+    store.dispatch(addTodo('Hello'));
+    store.dispatch(addTodo('World'));
+    expect(store.getState()).toEqual([{
+      id: 1,
+      text: 'Hello'
+    }, {
+      id: 2,
+      text: 'World'
+    }]);
+    store.resetState();
+    expect(store.getState()).toEqual([]);
+  });
+
+  it('can resetState to new state value', () => {
+    const store = createStore(reducers.todos);
+    expect(store.getState()).toEqual([]);
+    store.resetState([{id: 1, text: 'Hello'}]);
+    store.dispatch(addTodo('World'));
+    expect(store.getState()).toEqual([{
+      id: 1,
+      text: 'Hello'
+    }, {
+      id: 2,
+      text: 'World'
+    }]);
   });
 });


### PR DESCRIPTION
Still named `resetState`, but takes an optional `newState` value, defaulting to `initialState`.