### PR TITLE
Skip triggering listeners if currentState === reducer(currentState, action)

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -98,6 +98,8 @@ export default function createStore(reducer, initialState) {
       throw new Error('Reducers may not dispatch actions.');
     }
 
+    var lastState = currentState;
+
     try {
       isDispatching = true;
       currentState = currentReducer(currentState, action);
@@ -105,7 +107,9 @@ export default function createStore(reducer, initialState) {
       isDispatching = false;
     }
 
-    listeners.slice().forEach(listener => listener());
+    if (lastState !== currentState) {
+      listeners.slice().forEach(listener => listener());
+    }
     return action;
   }
 

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -163,11 +163,11 @@ describe('createStore', () => {
     const listenerB = expect.createSpy(() => {});
 
     let unsubscribeA = store.subscribe(listenerA);
-    store.dispatch({});
+    store.dispatch(addTodo('Hello'));
     expect(listenerA.calls.length).toBe(1);
     expect(listenerB.calls.length).toBe(0);
 
-    store.dispatch({});
+    store.dispatch(addTodo('World'));
     expect(listenerA.calls.length).toBe(2);
     expect(listenerB.calls.length).toBe(0);
 
@@ -175,7 +175,7 @@ describe('createStore', () => {
     expect(listenerA.calls.length).toBe(2);
     expect(listenerB.calls.length).toBe(0);
 
-    store.dispatch({});
+    store.dispatch(addTodo('Hello'));
     expect(listenerA.calls.length).toBe(3);
     expect(listenerB.calls.length).toBe(1);
 
@@ -183,7 +183,7 @@ describe('createStore', () => {
     expect(listenerA.calls.length).toBe(3);
     expect(listenerB.calls.length).toBe(1);
 
-    store.dispatch({});
+    store.dispatch(addTodo('World'));
     expect(listenerA.calls.length).toBe(3);
     expect(listenerB.calls.length).toBe(2);
 
@@ -191,7 +191,7 @@ describe('createStore', () => {
     expect(listenerA.calls.length).toBe(3);
     expect(listenerB.calls.length).toBe(2);
 
-    store.dispatch({});
+    store.dispatch(addTodo('Hello'));
     expect(listenerA.calls.length).toBe(3);
     expect(listenerB.calls.length).toBe(2);
 
@@ -199,7 +199,7 @@ describe('createStore', () => {
     expect(listenerA.calls.length).toBe(3);
     expect(listenerB.calls.length).toBe(2);
 
-    store.dispatch({});
+    store.dispatch(addTodo('World'));
     expect(listenerA.calls.length).toBe(4);
     expect(listenerB.calls.length).toBe(2);
   });
@@ -217,8 +217,8 @@ describe('createStore', () => {
     });
     store.subscribe(listenerC);
 
-    store.dispatch({});
-    store.dispatch({});
+    store.dispatch(addTodo('Hello'));
+    store.dispatch(addTodo('World'));
 
     expect(listenerA.calls.length).toBe(2);
     expect(listenerB.calls.length).toBe(1);
@@ -293,5 +293,15 @@ describe('createStore', () => {
     expect(() =>
       store.dispatch({})
     ).toNotThrow();
+  });
+
+  it('should not trigger listeners unless the state has changed',  () => {
+    const store = createStore(reducers.todos);
+    const listenerA = expect.createSpy(() => {});
+    store.subscribe(listenerA);
+    store.dispatch({});
+    expect(listenerA.calls.length).toBe(0);
+    store.dispatch(addTodo('Hello'));
+    expect(listenerA.calls.length).toBe(1);
   });
 });


### PR DESCRIPTION
So this is probably too big of a change to have in the 1.x series, but I was thinking it'd be convenient if the listeners only fired when a change to the `currentState` value actually occurs.

In most cases when using the default `combineReducers` this won't be the case, but providing a reducer which wraps and does a shallow memoization it could save some extra overhead of calling every listener on every dispatch.
