### PR TITLE
fix(real-world-example): lock react-router version

### DIFF
--- a/examples/real-world/package.json
+++ b/examples/real-world/package.json
@@ -21,7 +21,7 @@
     "normalizr": "^1.0.0",
     "react": "^0.13.3",
     "react-redux": "^1.0.1",
-    "react-router": "^1.0.0-beta3",
+    "react-router": "1.0.0-beta3",
     "redux": "^1.0.1",
     "redux-logger": "0.0.1",
     "redux-thunk": "^0.1.0"


### PR DESCRIPTION
Previously the real world example was not working due to a difference in
the file structure in react-router 1.0.0-beta4

The following error was being raised:

 > Module not found: Error: Cannot resolve module
 > 'react-router/lib/BrowserHistory' in /tmp/redux/examples/real-world

The version has been locked to react-router 1.0.0-beta3 to ensure the
example still runs. When the documentation has been updated for
react-router it would be ideal to update this to use the latest version
so the demo is up to date.