### PR TITLE
Fixed example in WritingTests.md.

### DIFF
--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -57,7 +57,7 @@ describe('actions', () => {
     };
     expect(actions.addTodo(text)).toEqual(expectedAction);
   });
-}
+});
 ```
 
 ### Reducers


### PR DESCRIPTION
Fixed a syntactical error in one of the first examples of [WritingTests.md](https://github.com/rackt/redux/blob/master/docs/recipes/WritingTests.md).