### PR TITLE
Remove getReducer() from Store API

### DIFF
--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -97,7 +97,6 @@ type Store = {
   dispatch: Dispatch;
   getState: () => State;
   subscribe: (listener: () => void) => () => void;
-  getReducer: () => Reducer;
   replaceReducer: (reducer: Reducer) => void;
 };
 ```
@@ -108,7 +107,7 @@ There should only be a single store in a Redux app, as the composition happens o
 - [`dispatch(action)`](api/Store.md#dispatch) is the base dispatch function described above.
 - [`getState()`](api/Store.md#getState) returns the current state of the store.
 - [`subscribe(listener)`](api/Store.md#subscribe) registers a function to be called on state changes.
-- [`getReducer()`](api/Store.md#getReducer) and [`replaceReducer(nextReducer)`](api/Store.md#replaceReducer) can be used to implement hot reloading and code splitting. Most likely you won’t use them.
+- [`replaceReducer(nextReducer)`](api/Store.md#replaceReducer) can be used to implement hot reloading and code splitting. Most likely you won’t use it.
 
 See the complete [store API reference](api/Store.md#dispatch) for more details.
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -18,7 +18,6 @@ This section documents the complete Redux API. Keep in mind that Redux is only c
   * [getState()](Store.md#getState)
   * [dispatch(action)](Store.md#dispatch)
   * [subscribe(listener)](Store.md#subscribe)
-  * [getReducer()](Store.md#getReducer)
   * [replaceReducer(nextReducer)](Store.md#replaceReducer)
 
 ### Importing

--- a/docs/api/Store.md
+++ b/docs/api/Store.md
@@ -15,7 +15,6 @@ To create it, pass your root [reducing function](../Glossary.md#reducer) to [`cr
 - [`getState()`](#getState)
 - [`dispatch(action)`](#dispatch)
 - [`subscribe(listener)`](#subscribe)
-- [`getReducer()`](#getReducer)
 - [`replaceReducer(nextReducer)`](#replaceReducer)
 
 ## Store Methods
@@ -115,23 +114,6 @@ function handleChange() {
 let unsubscribe = store.subscribe(handleChange);
 handleChange();
 ```
-
-<hr>
-
-### <a id='getReducer'></a>[`getReducer()`](#getReducer)
-
->##### Deprecated
-
->This API has been [deprecated](https://github.com/rackt/redux/issues/350).  
->It will be removed when we find a better solution for this problem.
-
-Returns the reducer currently used by the store to calculate the state.
-
-It is an advanced API. You might only need this if you implement a hot reloading mechanism for Redux.
-
-#### Returns
-
-(*Function*): The store’s current reducer.
 
 <hr>
 

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -110,18 +110,6 @@ export default function createStore(reducer, initialState) {
   }
 
   /**
-   * Returns the reducer currently used by the store to calculate the state.
-   *
-   * It is likely that you will only need this function if you implement a hot
-   * reloading mechanism for Redux.
-   *
-   * @returns {Function} The reducer used by the current store.
-   */
-  function getReducer() {
-    return currentReducer;
-  }
-
-  /**
    * Replaces the reducer currently used by the store to calculate the state.
    *
    * You might need this if your app implements code splitting and you want to
@@ -136,7 +124,6 @@ export default function createStore(reducer, initialState) {
     dispatch({ type: ActionTypes.INIT });
   }
 
-
   // When a store is created, an "INIT" action is dispatched so that every
   // reducer returns their initial state. This effectively populates
   // the initial state tree.
@@ -146,7 +133,6 @@ export default function createStore(reducer, initialState) {
     dispatch,
     subscribe,
     getState,
-    getReducer,
     replaceReducer
   };
 }

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -8,11 +8,10 @@ describe('createStore', () => {
     const store = createStore(combineReducers(reducers));
     const methods = Object.keys(store);
 
-    expect(methods.length).toBe(5);
+    expect(methods.length).toBe(4);
     expect(methods).toContain('subscribe');
     expect(methods).toContain('dispatch');
     expect(methods).toContain('getState');
-    expect(methods).toContain('getReducer');
     expect(methods).toContain('replaceReducer');
   });
 
@@ -106,8 +105,7 @@ describe('createStore', () => {
       text: 'World'
     }]);
 
-    let nextStore = createStore(reducers.todosReverse);
-    store.replaceReducer(nextStore.getReducer());
+    store.replaceReducer(reducers.todosReverse);
     expect(store.getState()).toEqual([{
       id: 1,
       text: 'Hello'
@@ -128,8 +126,7 @@ describe('createStore', () => {
       text: 'World'
     }]);
 
-    nextStore = createStore(reducers.todos);
-    store.replaceReducer(nextStore.getReducer());
+    store.replaceReducer(reducers.todos);
     expect(store.getState()).toEqual([{
       id: 3,
       text: 'Perhaps'


### PR DESCRIPTION
It was only needed because React Redux used it to magically allow reducer hot reloading.
This magic used to cause problems (https://github.com/rackt/redux/issues/301, https://github.com/rackt/redux/issues/340), so we made the usage of `replaceReducer()` for hot reloading explicit (https://github.com/rackt/redux/pull/667). Now that it is explicit, there is no need for `getReducer()` so it can safely be removed from the public API.

This is a breaking change, so it goes into `wip-2.0` branch.