### PR TITLE
Docs: Minor tweaks to advanced/ExampleRedditAPI.md

### DIFF
--- a/docs/advanced/ExampleRedditAPI.md
+++ b/docs/advanced/ExampleRedditAPI.md
@@ -98,7 +98,7 @@ import { combineReducers } from 'redux';
 import {
   SELECT_REDDIT, INVALIDATE_REDDIT,
   REQUEST_POSTS, RECEIVE_POSTS
-} from '../actions';
+} from './actions';
 
 function selectedReddit(state = 'reactjs', action) {
   switch (action.type) {
@@ -162,10 +162,10 @@ export default rootReducer;
 #### `configureStore.js`
 
 ```js
-import { createStore, applyMiddleware, combineReducers } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import loggerMiddleware from 'redux-logger';
-import rootReducer from '../reducers';
+import rootReducer from './reducers';
 
 const createStoreWithMiddleware = applyMiddleware(
   thunkMiddleware,


### PR DESCRIPTION
Three changes:

1. Removed ```combineReducers``` from ```import``` statement under configureStore.js (combineReducers is not used there).

2. The file names as listed on this page seem to imply that reducers.js and actions.js are in the same directory, so I changed the relative path of the import statement in reducers.js to match this. (from ```"../actions"``` to ```"./actions"```).

3. Same issue as number 2 above: configureStore.js and reducers.js seem to be in the same directory, so I changed the relative path of the import statement in configureStore.js to match this (from ```"../reducers"``` to ```"./reducers"```).