### PR TITLE
Removed unnecessary punctuation

### DIFF
--- a/docs/introduction/Examples.md
+++ b/docs/introduction/Examples.md
@@ -21,8 +21,8 @@ open http://localhost:3000/
 
 It covers:
 
-* Basic Redux flow;
-* Testing.
+* Basic Redux flow
+* Testing
 
 ## TodoMVC
 
@@ -40,9 +40,9 @@ open http://localhost:3000/
 
 It covers:
 
-* Redux flow with two reducers;
-* Updating nested data;
-* Testing.
+* Redux flow with two reducers
+* Updating nested data
+* Testing
 
 ## Async
 
@@ -60,9 +60,9 @@ open http://localhost:3000/
 
 It covers:
 
-* Basic async Redux flow with [redux-thunk](https://github.com/gaearon/redux-thunk);
-* Caching responses and showing a spinner while data is fetching;
-* Invalidating the cached data.
+* Basic async Redux flow with [redux-thunk](https://github.com/gaearon/redux-thunk)
+* Caching responses and showing a spinner while data is fetching
+* Invalidating the cached data
 
 ## Universal
 
@@ -100,12 +100,12 @@ open http://localhost:3000/
 
 It covers:
 
-* Real-world async Redux flow;
-* Keeping entities in a normalized entity cache;
-* A custom middleware for API calls;
-* Caching responses and showing a spinner while data is fetching;
-* Pagination;
-* Routing.
+* Real-world async Redux flow
+* Keeping entities in a normalized entity cache
+* A custom middleware for API calls
+* Caching responses and showing a spinner while data is fetching
+* Pagination
+* Routing
 
 ## More Examples
 


### PR DESCRIPTION
Bullets shouldn't end in any punctuation when they're not a complete sentence. If they are a complete sentence, they should end in a period. More info: https://www.google.com/search?client=safari&rls=en&q=bulleted+list+punctuation&ie=UTF-8&oe=UTF-8