### PR TITLE
Switch out contextify for vm

### DIFF
--- a/examples/todomvc/components/Header.js
+++ b/examples/todomvc/components/Header.js
@@ -12,7 +12,7 @@ class Header extends Component {
     return (
       <header className="header">
           <h1>todos</h1>
-          <TodoTextInput newTodo={true}
+          <TodoTextInput newTodo
                          onSave={this.handleSave.bind(this)}
                          placeholder="What needs to be done?" />
       </header>

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "babel-core": "^5.6.18",
     "babel-eslint": "^4.1.0",
     "babel-loader": "^5.1.4",
-    "contextify": "^0.1.14",
     "eslint": "^1.2.1",
     "eslint-config-airbnb": "0.0.8",
     "eslint-plugin-react": "^3.2.3",

--- a/test/utils/isPlainObject.spec.js
+++ b/test/utils/isPlainObject.spec.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 import isPlainObject from '../../src/utils/isPlainObject';
-import contextify from 'contextify';
+import vm from 'vm';
 
 describe('isPlainObject', () => {
   it('should return true only if plain object', () => {
@@ -8,8 +8,8 @@ describe('isPlainObject', () => {
       this.prop = 1;
     }
 
-    const sandbox = contextify();
-    sandbox.run('var fromAnotherRealm = {};');
+    const sandbox = { fromAnotherRealm: false };
+    vm.runInNewContext('fromAnotherRealm = {}', sandbox);
 
     expect(isPlainObject(sandbox.fromAnotherRealm)).toBe(true);
     expect(isPlainObject(new Test())).toBe(false);
@@ -18,7 +18,5 @@ describe('isPlainObject', () => {
     expect(isPlainObject(null)).toBe(false);
     expect(isPlainObject()).toBe(false);
     expect(isPlainObject({ 'x': 1, 'y': 2 })).toBe(true);
-
-    sandbox.dispose();
   });
 });


### PR DESCRIPTION
Since contextify is not working on newer node versions, this removes it in favor of the native `vm` module. 

This will resolve errors with #698.