### PR TITLE
Remove semi-colon from sample code

### DIFF
--- a/docs/advanced/AsyncActions.md
+++ b/docs/advanced/AsyncActions.md
@@ -294,7 +294,7 @@ Remember that reducers are just functions, so you can use functional composition
 ## Async Action Creators
 
 Finally, how do we use the synchronous action creators we [defined earlier](#synchronous-action-creators) together with network requests? The standard way to do it with Redux is to use the [Redux Thunk middleware](https://github.com/gaearon/redux-thunk). It comes in a separate package called `redux-thunk`. We’ll explain how middleware works in general [later](Middleware.md); for now, there is just one important thing you need to know: by using this specific middleware, an action creator can return a function instead an action object. This way, the function creator becomes a [thunk](https://en.wikipedia.org/wiki/Thunk).
- 
+
 When a function creator returns a function, that function will get executed by the Redux Thunk middleware. This function doesn’t need to be pure; it is thus allowed to have side effects, including executing asynchronous API calls. The function can also dispatch actions—like those synchronous actions we defined earlier.
 
 We can still define these special thunk action creators inside our `actions.js` file:
@@ -399,7 +399,7 @@ const store = createStoreWithMiddleware(rootReducer);
 
 store.dispatch(selectReddit('reactjs'));
 store.dispatch(fetchPosts('reactjs')).then(() =>
-  console.log(store.getState());
+  console.log(store.getState())
 );
 ```
 


### PR DESCRIPTION
Just a simple diff to the docs where I removed a semi-colon that causes a syntax error when running the code.