### PR TITLE
Catch errors in listeners

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -118,10 +118,9 @@ export default function createStore(reducer, initialState) {
     }
 
     listeners.slice().forEach(listener => {
-      try{
+      try {
         listener();
-      }
-      catch(err){
+      } catch (err) {
         console.error(err);
       }
     });

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -117,7 +117,14 @@ export default function createStore(reducer, initialState) {
       isDispatching = false;
     }
 
-    listeners.slice().forEach(listener => listener());
+    listeners.slice().forEach(listener => {
+      try{
+        listener();
+      }
+      catch(err){
+        console.error(err);
+      }
+    });
     return action;
   }
 


### PR DESCRIPTION
Hi, 
I noticed that errors are silently swallowed in createStore.js

```javascript
listeners.slice().forEach(function (listener) {
    listener();
});
```

something like this might be more helpful:

```javascript
listeners.slice().forEach(function (listener) {
    try{
        listener();
    }
    catch(err){
        console.error(err);
    }
});
```