### PR TITLE
Don't render directly to document.body

### DIFF
--- a/examples/real-world/createDevToolsWindow.js
+++ b/examples/real-world/createDevToolsWindow.js
@@ -7,15 +7,21 @@ import { DevTools, DebugPanel, LogMonitor } from 'redux-devtools/lib/react';
  * Based on https://gist.github.com/tlrobinson/1e63d15d3e5f33410ef7#gistcomment-1560218.
  */
 export default function createDevToolsWindow(store) {
+  // Window name.
+  const name = 'Redux DevTools';
+  
   // Give it a name so it reuses the same window.
   const win = window.open(
     null,
-    'Redux DevTools',
+    name,
     'menubar=no,location=no,resizable=yes,scrollbars=no,status=no'
   );
 
   // Reload in case it's reusing the same window with the old content.
   win.location.reload();
+  
+  // Set visible Window title.
+  win.document.title = name;
 
   // Wait a little bit for it to reload, then render.
   setTimeout(() => render(

--- a/examples/real-world/createDevToolsWindow.js
+++ b/examples/real-world/createDevToolsWindow.js
@@ -22,6 +22,6 @@ export default function createDevToolsWindow(store) {
     <DebugPanel top right bottom left>
       <DevTools store={store} monitor={LogMonitor} />
     </DebugPanel>,
-    win.document.body
+    win.document.body.appendChild(document.createElement('div'))
   ), 10);
 }


### PR DESCRIPTION
Fix warning about rendering components directly into document.body which comes with React 0.14 (ReactDom respectively).
Instead, render into DIV created on the fly.