### PR TITLE
Fix link to Usage with React page

### DIFF
--- a/docs/recipes/ServerRendering.md
+++ b/docs/recipes/ServerRendering.md
@@ -70,7 +70,7 @@ app.listen(port);
 
 The first thing that we need to do on every request is create a new Redux store instance. The only purpose of this store instance is to provide the initial state of our application.
 
-When rendering, we will wrap `<App />`, our root component, inside a `<Provider>` to make the store available to all components in the component tree, as we saw in [Usage with React](/docs/basics/UsageWithReact.html).
+When rendering, we will wrap `<App />`, our root component, inside a `<Provider>` to make the store available to all components in the component tree, as we saw in [Usage with React](../basics/UsageWithReact.md).
 
 The key step in server side rendering is to render the initial HTML of our component _**before**_ we send it to the client side. To do this, we use [React.renderToString()](https://facebook.github.io/react/docs/top-level-api.html#react.rendertostring).
 


### PR DESCRIPTION
The href in the [rendered page](http://rackt.github.io/redux/docs/recipes/ServerRendering.html) currently leads to a 404.