### PR TITLE
Doc: Don’t call non-pure functions in a reducer

### DIFF
--- a/docs/basics/Reducers.md
+++ b/docs/basics/Reducers.md
@@ -41,7 +41,8 @@ Now that we’ve decided what our state object looks like, we’re ready to writ
 It’s called a reducer because it’s the type of function you would pass to [`Array.prototype.reduce(reducer, ?initialValue)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce). It’s very important that the reducer stays pure. Things you should **never** do inside a reducer:
 
 * Mutate its arguments;
-* Perform side effects like API calls and routing transitions.
+* Perform side effects like API calls and routing transitions;
+* Calling non-pure functions, e.g. `Date.now()` or `Math.random()`.
 
 We’ll explore how to perform side effects in the [advanced walkthrough](../advanced/README.md). For now, just remember that the reducer must be pure. **Given the same arguments, it should calculate the next state and return it. No surprises. No side effects. No API calls. No mutations. Just a calculation.**
 


### PR DESCRIPTION
The first time I use Redux, I did some silly things like this:

```js
  case ADD_TODO:
    return Object.assign({}, state, {
      todos: [...state.todos, {
        id: uuid.v4(), // ｉｍｐｕｒｅ！！！　๐·°(৹˃̵﹏˂̵৹)°·๐
        text: action.text,
        completed: false
      }]
    });
```

Here, `uuid.v4()` is not pure. This causes the state to be unpredictable. I had to come back and move this impure code to the action creator later. So I hope this docs change can prevent future mistakes like this.