### PR TITLE
move combine reducers sanity check #717

### DIFF
--- a/test/utils/combineReducers.spec.js
+++ b/test/utils/combineReducers.spec.js
@@ -66,8 +66,8 @@ describe('Utils', () => {
       );
     });
 
-    it('should throw an error if a reducer returns undefined initializing', () => {
-      expect(() => combineReducers({
+    it('should throw an error on first call if a reducer returns undefined initializing', () => {
+      const reducer = combineReducers({
         counter(state, action) {
           switch (action.type) {
           case 'increment':
@@ -78,7 +78,8 @@ describe('Utils', () => {
             return state;
           }
         }
-      })).toThrow(
+      });
+      expect(() => reducer({})).toThrow(
         /"counter".*initialization/
       );
     });
@@ -100,8 +101,8 @@ describe('Utils', () => {
       expect(reducer({counter: 0}, { type: increment }).counter).toEqual(1);
     });
 
-    it('should throw an error if a reducer attempts to handle a private action', () => {
-      expect(() => combineReducers({
+    it('should throw an error on first call if a reducer attempts to handle a private action', () => {
+      const reducer = combineReducers({
         counter(state, action) {
           switch (action.type) {
           case 'increment':
@@ -115,7 +116,8 @@ describe('Utils', () => {
             return undefined;
           }
         }
-      })).toThrow(
+      });
+      expect(() => reducer()).toThrow(
         /"counter".*private/
       );
     });


### PR DESCRIPTION
Creates and logs sanity check error during `combineReducers`, but only throws on first invocation. Addresses #717.