### PR TITLE
Transaction behaviour of dispatch()

### DIFF
--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -8,11 +8,13 @@ describe('createStore', () => {
     const store = createStore(combineReducers(reducers));
     const methods = Object.keys(store);
 
-    expect(methods.length).toBe(4);
+    expect(methods.length).toBe(6);
     expect(methods).toContain('subscribe');
     expect(methods).toContain('dispatch');
     expect(methods).toContain('getState');
     expect(methods).toContain('replaceReducer');
+    expect(methods).toContain('begin');
+    expect(methods).toContain('commit');
   });
 
   it('should require a reducer function', () => {
@@ -320,5 +322,24 @@ describe('createStore', () => {
     expect(() =>
       store.dispatch({ type: '' })
     ).toNotThrow();
+  });
+
+  it('should not call listeners if begin() called', () => {
+    const store = createStore(reducers.todos);
+    let called = false;
+    store.subscribe(() => {
+      called = true;
+    });
+
+    store.dispatch({type: 'test'});
+    expect(called).toBe(true);
+    called = false;
+
+    store.begin();
+    store.dispatch({type: 'test'});
+    expect(called).toBe(false);
+
+    store.commit();
+    expect(called).toBe(true);
   });
 });


### PR DESCRIPTION
Hi!
Each store.dispatch(/* some action */) will invoke all listeners callbacks. This can lead to a lot of unnecessary calls.
I propose to add some transaction-like behaviour.
```javascript
store.begin();
store.dispatch({type: 1});
store.dispatch({type: 2});
// ...
store.dispatch({type: 100});
store.commit(); // and invoke listeners callbacks one time at the end
```
It seems to me, that the idea of transaction would be very useful in redux. But this PR has big changes in API and need some work. 
Maybe another API seem more successful. Something like this easier to implement:
```javascript
function dispatch(action, notNotify=false) {
// ...
}

// in app
store.dispatch({type: 1}, true);
store.dispatch({type: 2}, true);
// ...
store.dispatch({type: 100}); // and invoke listeners callbacks one time at the end
```