### PR TITLE
Revised middleware-declaration function's interface

### DIFF
--- a/src/utils/applyMiddleware.js
+++ b/src/utils/applyMiddleware.js
@@ -26,7 +26,7 @@ export default function applyMiddleware(...middlewares) {
       getState: store.getState,
       dispatch: (action) => dispatch(action)
     };
-    chain = middlewares.map(middleware => middleware(middlewareAPI));
+    chain = middlewares.map(middleware => middleware.length === 2 ? middleware.bind(undefined, middlewareAPI) : middleware(middlewareAPI));
     dispatch = compose(...chain)(store.dispatch);
 
     return {

--- a/test/utils/applyMiddleware.spec.js
+++ b/test/utils/applyMiddleware.spec.js
@@ -7,9 +7,9 @@ import { thunk } from '../helpers/middleware';
 describe('applyMiddleware', () => {
   it('wraps dispatch method with middleware once', () => {
     function test(spyOnMethods) {
-      return methods => {
+      return (methods, next) => {
         spyOnMethods(methods);
-        return next => action => next(action);
+        return action => next(action);
       };
     }
 


### PR DESCRIPTION
The current middleware declaration function is required to return a function to intercept the first two dependencies used to construct the middleware (curry).

Since the actual middleware construction requires "store" (or its simulated API) and "next" (next middleware's "dispatch") to both be available at the time of the middleware's function declaration, and since they're both available right at the time of "applyMiddleware"'s invocation, there is essentially no need to split the two arguments into different function calls.

This PR includes support for both 2 and 1 (for existing middleware) arguments definition funcs:

```const myMiddleWare = store => next => action => next(action)```

or

```const myMiddleWare = (store, next) => action => next(action)```

more friendly towards ES5 newcomers (and Express middleware authors):

```javascript
var myMiddleWare = function(store, next){

  return function(action){   
    // process action
    ...
    // proceed to next middleware
    next(action)
  }

}
```

I believe this minor change could promote authors' familiarity and understanding, thus encourage the development of additional middleware to Redux.
