### PR TITLE
Fix bug caused by inconsistent Todo state across components in the Basic chapter of the Docs

### DIFF
--- a/docs/basics/UsageWithReact.md
+++ b/docs/basics/UsageWithReact.md
@@ -152,17 +152,20 @@ export default class TodoList extends Component {
   render() {
     return (
       <ul>
-        {this.props.todos.map((todo, index) =>
-          <Todo {...todo}
-                key={index}
-                onClick={() => this.props.onTodoClick(index)} />
-        )}
+        {this.props.todos.map((todo, index) => {
+          if (this.props.filteringCriteria(todo)) {
+            return <Todo {...todo}
+                         key={index}
+                         onClick={() => this.props.onTodoClick(index)}/>
+          }
+        })}
       </ul>
     );
   }
 }
 
 TodoList.propTypes = {
+  filteringCriteria: PropTypes.func.isRequired,
   onTodoClick: PropTypes.func.isRequired,
   todos: PropTypes.arrayOf(PropTypes.shape({
     text: PropTypes.string.isRequired,
@@ -313,7 +316,7 @@ import Footer from '../components/Footer';
 class App extends Component {
   render() {
     // Injected by connect() call:
-    const { dispatch, visibleTodos, visibilityFilter } = this.props;
+    const { dispatch, todos, filteringCriteria, visibilityFilter } = this.props;
     return (
       <div>
         <AddTodo
@@ -321,7 +324,8 @@ class App extends Component {
             dispatch(addTodo(text))
           } />
         <TodoList
-          todos={visibleTodos}
+          todos={todos}
+          filteringCriteria={filteringCriteria}
           onTodoClick={index =>
             dispatch(completeTodo(index))
           } />
@@ -336,7 +340,8 @@ class App extends Component {
 }
 
 App.propTypes = {
-  visibleTodos: PropTypes.arrayOf(PropTypes.shape({
+  filteringCriteria: PropTypes.func.isRequired,
+  todos: PropTypes.arrayOf(PropTypes.shape({
     text: PropTypes.string.isRequired,
     completed: PropTypes.bool.isRequired
   })),
@@ -347,14 +352,15 @@ App.propTypes = {
   ]).isRequired
 };
 
-function selectTodos(todos, filter) {
+
+function selectTodos(filter) {
   switch (filter) {
   case VisibilityFilters.SHOW_ALL:
-    return todos;
+    return function(todo){return true}
   case VisibilityFilters.SHOW_COMPLETED:
-    return todos.filter(todo => todo.completed);
+    return function(todo){return todo.completed};
   case VisibilityFilters.SHOW_ACTIVE:
-    return todos.filter(todo => !todo.completed);
+    return function(todo){return !todo.completed};
   }
 }
 
@@ -362,8 +368,9 @@ function selectTodos(todos, filter) {
 // Note: use https://github.com/faassen/reselect for better performance.
 function select(state) {
   return {
-    visibleTodos: selectTodos(state.todos, state.visibilityFilter),
-    visibilityFilter: state.visibilityFilter
+    todos: state.todos,
+    visibilityFilter: state.visibilityFilter,
+    filteringCriteria: selectTodos(state.visibilityFilter)
   };
 }
 

--- a/docs/basics/UsageWithReact.md
+++ b/docs/basics/UsageWithReact.md
@@ -66,6 +66,7 @@ I see the following components (and their props) emerge from this brief:
   - `onAddClick(text: string)` is a callback to invoke when a button is pressed.
 * **`TodoList`** is a list showing visible todos.
   - `todos: Array` is an array of todo items with `{ text, completed }` shape.
+  - `filteringCriteria(todo: object)` contains the rules for how TodoList should filter its list of todos.
   - `onTodoClick(index: number)` is a callback to invoke when a todo is clicked.
 * **`Todo`** is a single todo item.
   - `text: string` is the text to show.
@@ -247,6 +248,7 @@ export default class App extends Component {
             text: 'Learn to connect it to React',
             completed: false
           }]}
+          filteringCriteria={function(todo){return true}}
           onTodoClick={todo =>
             console.log('todo clicked', todo)
           } />
@@ -351,7 +353,6 @@ App.propTypes = {
     'SHOW_ACTIVE'
   ]).isRequired
 };
-
 
 function selectTodos(filter) {
   switch (filter) {


### PR DESCRIPTION
The tutorial for the TodoMVC app in documentation, the visibleTodos prop is passed to TodoList, which is mapped into a new array -- which I will call visibleTodos -- and rendered into Todo components. Upon doing so, the visibleTodos array now is at risk of becoming unlinked with the state.todos array as soon as a single item is completed. 

Because the completeTodo reducer relies on parity between the indexes of the visibleTodos array and the state.todos array, bugs can occur when in trying to dispatch a completeTodo action in SHOW_ACTIVE view mode. The bug occurs because the visibleTodos array can be shorter than the state.todos array, and any index in the list can be filtered out once completed. 

In the screen shot below, "third" has already been completed. When clicking on "fourth" todo  -- the fourth item in the state.todos array and third item in the visibleTodos array, the payload informs the app that it should complete the third item in the array, so nothing happens. 
![screen shot 2015-09-24 at 10 20 41 am](https://cloud.githubusercontent.com/assets/7918530/10075840/095aecec-62a6-11e5-86b5-dae69eb5a56b.png)

Likewise, when clicking on the "fifth" todo --- fifth in state.todos but fourth in visibleTodos, it completes the "fourth" item by dispatching a payload targeting the index: 3.
![screen shot 2015-09-24 at 10 21 03 am](https://cloud.githubusercontent.com/assets/7918530/10075901/5e758ba6-62a6-11e5-993f-8bd71a0447ff.png)

I have crafted two solutions. The first is to map a uuid to each todo and have the completeTodo action splice the array using the index returned by Array.prototype.findIndex(todo.id) instead of the current position of the Todo in the visibleTodos array. This solution fixes the inaccuracies of the reducer, but it also requires actions and the reducer to be rewritten and another module to be installed.  I'm not a fan.

Instead, why not pass the filtering mechanisms themselves to TodoList component via props by altering the selectTodos helper to return functions instead of filtered arrays? Now we are free to pass the entire state.todos array to TodoList and simply not render any todo within it that doesn't return true when passed to the filtering function. This keeps our state consistent across components without altering any reducers or actions. I believe this to be the elegant solution. It is included in this PR. 

My apologies for such a big switch.