### PR TITLE
Migrating docs: point to `createStore()` source file

### DIFF
--- a/docs/recipes/MigratingToRedux.md
+++ b/docs/recipes/MigratingToRedux.md
@@ -13,7 +13,7 @@ It is also possible to do the reverse and migrate from Redux to any of these lib
 
 Your process will look like this:
 
-* Create a function called `createFluxStore(reducer)` that creates a Flux store compatible with your existing app from a reducer function. Internally it might look similar to [`createStore`](../api/createStore.md) implementation from Redux. Its dispatch handler should just call the `reducer` for any action, store the next state, and emit change.
+* Create a function called `createFluxStore(reducer)` that creates a Flux store compatible with your existing app from a reducer function. Internally it might look similar to [`createStore`](../api/createStore.md) ([source](https://github.com/rackt/redux/blob/master/src/createStore.js)) implementation from Redux. Its dispatch handler should just call the `reducer` for any action, store the next state, and emit change.
 
 * This allows you to gradually rewrite every Flux Store in your app as a reducer, but still export `createFluxStore(reducer)` so the rest of your app is not aware that this is happening and sees the Flux stores.
 


### PR DESCRIPTION
Feel free to close the PR if you disagree, although since it suggests to check the `createStore` implementation, I think it makes more sense to link to it, rather than to the API docs.