### PR TITLE
change todo to todoIndex in the example codes: App.js 

### DIFF
--- a/docs/basics/UsageWithReact.md
+++ b/docs/basics/UsageWithReact.md
@@ -244,8 +244,8 @@ export default class App extends Component {
             text: 'Learn to connect it to React',
             completed: false
           }]}
-          onTodoClick={todo =>
-            console.log('todo clicked', todo)
+          onTodoClick={todoIndex =>
+            console.log('todo clicked', todoIndex)
           } />
         <Footer
           filter='SHOW_ALL'


### PR DESCRIPTION
In line 156-158 :
```js
 <Todo {...todo}
                key={index}
                onClick={() => this.props.onTodoClick(index)} />
```

There is index of todo.
But in the line 239-249:

```js
<TodoList
          todos={[{
            text: 'Use Redux',
            completed: true
          }, {
            text: 'Learn to connect it to React',
            completed: false
          }]}
          onTodoClick={todo=>
            console.log('todo clicked', todo)
          } />
```
There become just the `todo`,
I think change it to `todoIndex` would be clearer and less ambiguous than just `todo`.