### PR TITLE
Update babel config for new transform format

### DIFF
--- a/examples/async/.babelrc
+++ b/examples/async/.babelrc
@@ -6,11 +6,13 @@
         "react-transform"
       ],
       "extra": {
-        "react-transform": [{
-          "target":  "react-transform-hmr",
-          "imports": ["react"],
-          "locals":  ["module"]
-        }]
+        "react-transform": {
+          "transforms": [{
+            "transform":  "react-transform-hmr",
+            "imports": ["react"],
+            "locals":  ["module"]
+          }]
+        }
       }
     }
   }

--- a/examples/counter/.babelrc
+++ b/examples/counter/.babelrc
@@ -6,11 +6,13 @@
         "react-transform"
       ],
       "extra": {
-        "react-transform": [{
-          "target":  "react-transform-hmr",
-          "imports": ["react"],
-          "locals":  ["module"]
-        }]
+        "react-transform": {
+          "transforms": [{
+            "transform":  "react-transform-hmr",
+            "imports": ["react"],
+            "locals":  ["module"]
+          }]
+        }
       }
     }
   }

--- a/examples/real-world/.babelrc
+++ b/examples/real-world/.babelrc
@@ -6,11 +6,13 @@
         "react-transform"
       ],
       "extra": {
-        "react-transform": [{
-          "target":  "react-transform-hmr",
-          "imports": ["react"],
-          "locals":  ["module"]
-        }]
+        "react-transform": {
+          "transforms": [{
+            "transform":  "react-transform-hmr",
+            "imports": ["react"],
+            "locals":  ["module"]
+          }]
+        }
       }
     }
   }

--- a/examples/todomvc/.babelrc
+++ b/examples/todomvc/.babelrc
@@ -6,11 +6,13 @@
         "react-transform"
       ],
       "extra": {
-        "react-transform": [{
-          "target":  "react-transform-hmr",
-          "imports": ["react"],
-          "locals":  ["module"]
-        }]
+        "react-transform": {
+          "transforms": [{
+            "transform":  "react-transform-hmr",
+            "imports": ["react"],
+            "locals":  ["module"]
+          }]
+        }
       }
     }
   }

--- a/examples/todos-with-undo/.babelrc
+++ b/examples/todos-with-undo/.babelrc
@@ -6,11 +6,13 @@
         "react-transform"
       ],
       "extra": {
-        "react-transform": [{
-          "target":  "react-transform-hmr",
-          "imports": ["react"],
-          "locals":  ["module"]
-        }]
+        "react-transform": {
+          "transforms": [{
+            "transform":  "react-transform-hmr",
+            "imports": ["react"],
+            "locals":  ["module"]
+          }]
+        }
       }
     }
   }

--- a/examples/universal/webpack.config.js
+++ b/examples/universal/webpack.config.js
@@ -32,11 +32,13 @@ module.exports = {
               'react-transform'
             ],
             extra: {
-              'react-transform': [{
-                target:  'react-transform-hmr',
-                imports: ['react'],
-                locals:  ['module']
-              }]
+              'react-transform': {
+                transforms: [{
+                  transform:  'react-transform-hmr',
+                  imports: ['react'],
+                  locals:  ['module']
+                }]
+              }
             }
           }
         }


### PR DESCRIPTION
## Issue

When using v1.1.0 of the babel-plugin-react-transform, it throws warnings that the format for transforms is outdated and needs to be updated.

## Job Story

N/A

## Solution

Update the babel-plugin-react-transform config format to the new, non-deprecated format from upstream. (v1.1.0+)