### PR TITLE
Update babel-plugin-react-transform to 1.1.0

### DIFF
--- a/examples/async/package.json
+++ b/examples/async/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "babel-core": "^5.6.18",
     "babel-loader": "^5.1.4",
-    "babel-plugin-react-transform": "^1.0.3",
+    "babel-plugin-react-transform": "^1.1.0",
     "expect": "^1.6.0",
     "express": "^4.13.3",
     "jsdom": "^5.6.1",

--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "babel-core": "^5.6.18",
     "babel-loader": "^5.1.4",
-    "babel-plugin-react-transform": "^1.0.3",
+    "babel-plugin-react-transform": "^1.1.0",
     "expect": "^1.6.0",
     "express": "^4.13.3",
     "jsdom": "^5.6.1",

--- a/examples/real-world/package.json
+++ b/examples/real-world/package.json
@@ -33,7 +33,7 @@
     "babel-core": "^5.6.18",
     "babel-loader": "^5.1.4",
     "redux-devtools": "^2.1.5",
-    "babel-plugin-react-transform": "^1.0.3",
+    "babel-plugin-react-transform": "^1.1.0",
     "concurrently": "^0.1.1",
     "express": "^4.13.3",
     "react-transform-hmr": "^1.0.0",

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "babel-core": "^5.6.18",
     "babel-loader": "^5.1.4",
-    "babel-plugin-react-transform": "^1.0.3",
+    "babel-plugin-react-transform": "^1.1.0",
     "expect": "^1.8.0",
     "express": "^4.13.3",
     "jsdom": "^5.6.1",

--- a/examples/todos-with-undo/package.json
+++ b/examples/todos-with-undo/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "babel-core": "^5.6.18",
     "babel-loader": "^5.1.4",
-    "babel-plugin-react-transform": "^1.0.3",
+    "babel-plugin-react-transform": "^1.1.0",
     "expect": "^1.6.0",
     "express": "^4.13.3",
     "jsdom": "^5.6.1",

--- a/examples/universal/package.json
+++ b/examples/universal/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "babel-core": "^5.8.22",
     "babel-loader": "^5.3.2",
-    "babel-plugin-react-transform": "^1.0.3",
+    "babel-plugin-react-transform": "^1.1.0",
     "babel-runtime": "^5.8.20",
     "react-transform-hmr": "^1.0.0",
     "webpack": "^1.11.0",


### PR DESCRIPTION
Update babel-plugin-react-transform in package.json
to ^1.1.0 to support new format in babel config

See: https://github.com/gaearon/babel-plugin-react-transform/releases/tag/v1.1.0