### PR TITLE
Upgrade redux-logger to 2.0.2 in examples

### DIFF
--- a/examples/async/package.json
+++ b/examples/async/package.json
@@ -30,7 +30,7 @@
     "react": "^0.13.3",
     "react-redux": "^2.1.2",
     "redux": "^3.0.0",
-    "redux-logger": "0.0.3",
+    "redux-logger": "^2.0.2",
     "redux-thunk": "^0.1.0"
   },
   "devDependencies": {

--- a/examples/async/store/configureStore.js
+++ b/examples/async/store/configureStore.js
@@ -1,11 +1,11 @@
 import { createStore, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
-import loggerMiddleware from 'redux-logger';
+import createLogger from 'redux-logger';
 import rootReducer from '../reducers';
 
 const createStoreWithMiddleware = applyMiddleware(
   thunkMiddleware,
-  loggerMiddleware
+  createLogger()
 )(createStore);
 
 export default function configureStore(initialState) {

--- a/examples/real-world/package.json
+++ b/examples/real-world/package.json
@@ -25,7 +25,7 @@
     "react-redux": "^2.1.2",
     "react-router": "^1.0.0-rc1",
     "redux": "^3.0.0",
-    "redux-logger": "0.0.1",
+    "redux-logger": "^2.0.2",
     "redux-router": "^1.0.0-beta3",
     "redux-thunk": "^0.1.0"
   },

--- a/examples/real-world/store/configureStore.js
+++ b/examples/real-world/store/configureStore.js
@@ -5,13 +5,13 @@ import createHistory from 'history/lib/createBrowserHistory';
 import routes from '../routes';
 import thunk from 'redux-thunk';
 import api from '../middleware/api';
-import logger from 'redux-logger';
+import createLogger from 'redux-logger';
 import rootReducer from '../reducers';
 
 const finalCreateStore = compose(
   applyMiddleware(thunk, api),
   reduxReactRouter({ routes, createHistory }),
-  applyMiddleware(logger),
+  applyMiddleware(createLogger()),
   devTools()
 )(createStore);
 


### PR DESCRIPTION
Upgrades redux-logger from 0.0.x to 2.0.2 in async and real-world examples.
`redux-logger` now exports a function and not directly a middleware.