### PR TITLE
Filter out undefined values from compose()

### DIFF
--- a/src/utils/compose.js
+++ b/src/utils/compose.js
@@ -6,5 +6,7 @@
  * left. For example, compose(f, g, h) is identical to arg => f(g(h(arg))).
  */
 export default function compose(...funcs) {
-  return arg => funcs.reduceRight((composed, f) => f(composed), arg);
+  return arg => funcs
+    .filter(Boolean)
+    .reduceRight((composed, f) => f(composed), arg);
 }

--- a/test/utils/compose.spec.js
+++ b/test/utils/compose.spec.js
@@ -21,5 +21,11 @@ describe('Utils', () => {
       expect(compose(b, c, a)(final)('')).toBe('bca');
       expect(compose(c, a, b)(final)('')).toBe('cab');
     });
+
+    it('ignores falsey arguments', () => {
+      const square = x => x * x;
+      expect(() => { return compose(square, undefined)(5); }).toNotThrow();
+      expect(compose(square, undefined)(5)).toBe(25);
+    });
   });
 });


### PR DESCRIPTION
Using redux-devtools, I would like to use this pattern to conditionally include the `devTools()` middleware:

```javascript
  const finalCreateStore = compose(
    applyMiddleware(createApiMiddleware(httpClient, apiClient)),
    __DEVTOOLS__ ? devTools() : undefined,
  )(createStore);
```

Unfortunately, this throws the error `TypeError: undefined is not a function` in compose.js.

In this PR, I've changed compose.js to filter out falsey values so you can use the inline ternery.

Tell me what you think, and if you would like any changes before accepting this.

P.S. I've never been all that enthused for TDD, but writing the (failing) test for this first, making the change and seeing it pass made creating this PR super simple :100: 