### PR TITLE
Make combineReducers more flexible about additional reducers' arguments

### DIFF
--- a/src/utils/combineReducers.js
+++ b/src/utils/combineReducers.js
@@ -108,7 +108,7 @@ export default function combineReducers(reducers) {
 
   var defaultState = mapValues(finalReducers, () => undefined);
 
-  return function combination(state = defaultState, action) {
+  return function combination(state = defaultState, action, ...rest) {
     if (sanityError) {
       throw sanityError;
     }
@@ -116,7 +116,7 @@ export default function combineReducers(reducers) {
     var hasChanged = false;
     var finalState = mapValues(finalReducers, (reducer, key) => {
       var previousStateForKey = state[key];
-      var nextStateForKey = reducer(previousStateForKey, action);
+      var nextStateForKey = reducer(previousStateForKey, action, ...rest);
       if (typeof nextStateForKey === 'undefined') {
         var errorMessage = getUndefinedStateErrorMessage(key, action);
         throw new Error(errorMessage);


### PR DESCRIPTION
Hi, a couple of days ago, when searching for an answer to my problem with inaccessible state data inside of nested reducers (created with ``combineReducers`` and other helpers), I've found a [similar question](https://github.com/rackt/redux/issues/749) with [a solution/proposition](https://github.com/rackt/redux/issues/749#issuecomment-141570236) to pass down additional arguments to the reducers, with required data to calculate state change.

Unfortunately, ``combineReducers`` generates combined reducer, which do not pass any arguments besides the previous state and any passed action to the nested reducers. My PR fixes this problem by simply passing "rest" of the arguments to other reducers (using spread operator).

I hope this is a valuable change to the code-base (well, it definitely helped me a lot to decouple my code into smaller chunks), if there is anything else to do about it (like changing the docs or writing some tests), please just let me know.