### PR TITLE
Remove useless code in applyMiddleware.js

### DIFF
--- a/src/utils/applyMiddleware.js
+++ b/src/utils/applyMiddleware.js
@@ -19,7 +19,7 @@ import compose from './compose';
 export default function applyMiddleware(...middlewares) {
   return (next) => (reducer, initialState) => {
     var store = next(reducer, initialState);
-    var dispatch = store.dispatch;
+    var dispatch = null;
     var chain = [];
 
     var middlewareAPI = {


### PR DESCRIPTION
The code is useless , the 'dispatch'  will override after compose(...chain) and in middlewareAPI.dispatch, the 'dispatch' is same as ‘dispatch’ which was overrided.