### PR TITLE
Docs: Wrap <code> to fit on 1280px wide screen.

### DIFF
--- a/docs/advanced/Middleware.md
+++ b/docs/advanced/Middleware.md
@@ -379,8 +379,9 @@ const timeoutScheduler = store => next => action => {
 };
 
 /**
- * Schedules actions with { meta: { raf: true } } to be dispatched inside a rAF loop frame.
- * Makes `dispatch` return a function to remove the action from the queue in this case.
+ * Schedules actions with { meta: { raf: true } } to be dispatched inside a rAF loop 
+ * frame.  Makes `dispatch` return a function to remove the action from the queue in 
+ * this case.
  */
 const rafScheduler = store => next => {
   let queuedActions = [];


### PR DESCRIPTION
Right now, it clips at "fra" in Chrome on a 1280px wide Pixel:

![](http://i.imgur.com/AFF8HAS.png)

This fixes that.