### PR TITLE
fix small typo

### DIFF
--- a/docs/introduction/PriorArt.md
+++ b/docs/introduction/PriorArt.md
@@ -35,7 +35,7 @@ Note that, even if your immutable library supports cursors, you shouldn’t use 
 
 ### Baobab
 
-[Baobab](https://github.com/Yomguithereal/baobab) is another popular library implementing immutable API for updating plain JavaScript objects. While you can use it with Redux, there is little benefit to use them together.
+[Baobab](https://github.com/Yomguithereal/baobab) is another popular library implementing immutable API for updating plain JavaScript objects. While you can use it with Redux, there is little benefit in using them together.
 
 Most of the functionality Baobab provides is related to updating the data with cursors, but Redux enforces that the only way to update the data is to dispatch an action. Therefore they solve the same problem differently, and don’t complement each other.
 

--- a/docs/introduction/PriorArt.md
+++ b/docs/introduction/PriorArt.md
@@ -35,7 +35,7 @@ Note that, even if your immutable library supports cursors, you shouldn’t use 
 
 ### Baobab
 
-[Baobab](https://github.com/Yomguithereal/baobab) is another popular library implementing immutable API for updating plain JavaScript objects. While you can use it with Redux, there is little benefit to them together.
+[Baobab](https://github.com/Yomguithereal/baobab) is another popular library implementing immutable API for updating plain JavaScript objects. While you can use it with Redux, there is little benefit to use them together.
 
 Most of the functionality Baobab provides is related to updating the data with cursors, but Redux enforces that the only way to update the data is to dispatch an action. Therefore they solve the same problem differently, and don’t complement each other.
 


### PR DESCRIPTION
- fixes small typo in `docs/introduction/PriorArt.md`