### PR TITLE
[use Set instead of Array]

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -37,7 +37,7 @@ export default function createStore(reducer, initialState) {
 
   var currentReducer = reducer;
   var currentState = initialState;
-  var listeners = [];
+  var listeners = new Set();
   var isDispatching = false;
 
   /**
@@ -58,11 +58,10 @@ export default function createStore(reducer, initialState) {
    * @returns {Function} A function to remove this change listener.
    */
   function subscribe(listener) {
-    listeners.push(listener);
+    listeners.add(listener);
 
     return function unsubscribe() {
-      var index = listeners.indexOf(listener);
-      listeners.splice(index, 1);
+      listeners.delete(listener);
     };
   }
 
@@ -117,7 +116,10 @@ export default function createStore(reducer, initialState) {
       isDispatching = false;
     }
 
-    listeners.slice().forEach(listener => listener());
+    for(let listener of listeners.values()){
+      listener();
+    }
+
     return action;
   }
 

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -116,9 +116,7 @@ export default function createStore(reducer, initialState) {
       isDispatching = false;
     }
 
-    for(let listener of listeners.values()){
-      listener();
-    }
+    listeners.forEach(listener => { listener(); });
 
     return action;
   }


### PR DESCRIPTION
- replace an Array with a Set ( ES2015 )

Since you use babel and all of the ES2015 goodies, I was wondering why not use things like `Set` and `Map`. 
They will be more perfomant on browsers that support them natively, and developer wise, I think they have a nicer API to work with, than plain old Arrays.