### PR TITLE
Improves Writing Tests doc.

### DIFF
--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -131,11 +131,16 @@ function mockStore(getState, expectedActions, done) {
 
       dispatch(action) {
         const expectedAction = expectedActions.shift();
-        expect(action).toEqual(expectedAction);
-        if (done && !expectedActions.length) {
-          done();
+        
+        try {
+          expect(action).toEqual(expectedAction);
+          if (done && !expectedActions.length) {
+            done();
+          }
+          return action;
+        } catch (e) {
+          done(e);
         }
-        return action;
       }
     }
   }

--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -113,12 +113,12 @@ const middlewares = [thunk];
 /**
  * Creates a mock of Redux store with middleware.
  */
-function mockStore(getState, expectedActions, onLastAction) {
+function mockStore(getState, expectedActions, done) {
   if (!Array.isArray(expectedActions)) {
     throw new Error('expectedActions should be an array of expected actions.');
   }
-  if (typeof onLastAction !== 'undefined' && typeof onLastAction !== 'function') {
-    throw new Error('onLastAction should either be undefined or function.');
+  if (typeof done !== 'undefined' && typeof done !== 'function') {
+    throw new Error('done should either be undefined or function.');
   }
 
   function mockStoreWithoutMiddleware() {
@@ -132,8 +132,8 @@ function mockStore(getState, expectedActions, onLastAction) {
       dispatch(action) {
         const expectedAction = expectedActions.shift();
         expect(action).toEqual(expectedAction);
-        if (onLastAction && !expectedActions.length) {
-          onLastAction();
+        if (done && !expectedActions.length) {
+          done();
         }
         return action;
       }


### PR DESCRIPTION
I had problems following [Writing Tests](https://github.com/rackt/redux/blob/master/docs/recipes/WritingTests.md). Tests where failing with timeouts instead of proper error messages. This pull request improves `mockStore` to properly pass any exception which may occur.

```
fetchPages
    1) creates FETCH_PAGES_SUCCESS when fetching pages has been done

  0 passing (2s)
  1 failing

  1) fetchPages creates FETCH_PAGES_SUCCESS when fetching pages has been done:
     Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
```

```
fetchPages
    1) creates FETCH_PAGES_SUCCESS when fetching pages has been done

  0 passing (47ms)
  1 failing

  1) fetchPages creates FETCH_PAGES_SUCCESS when fetching pages has been done:

      AssertionError: { type: 'FETCH_PAGES_SUCCESS',
  pages:
   [ { id: '5628946bd0771c0e054ec2d5' },
     { id: '5628946bd0771c0e054ec2d6' } ] } deepEqual { type: 'FETCH_PAGES_SUCCESS', pages: {} }
      + expected - actual

       {
      -  "pages": [
      -    {
      -      "id": "5628946bd0771c0e054ec2d5"
      -    }
      -    {
      -      "id": "5628946bd0771c0e054ec2d6"
      -    }
      -  ]
      +  "pages": {}
         "type": "FETCH_PAGES_SUCCESS"
       }
```