### PR TITLE
Cached Object string representation

### DIFF
--- a/src/utils/isPlainObject.js
+++ b/src/utils/isPlainObject.js
@@ -1,4 +1,5 @@
 var fnToString = (fn) => Function.prototype.toString.call(fn);
+var objStringValue = fnToString(Object);
 
 /**
  * @param {any} obj The object to inspect.
@@ -19,5 +20,5 @@ export default function isPlainObject(obj) {
 
   return typeof constructor === 'function'
     && constructor instanceof constructor
-    && fnToString(constructor) === fnToString(Object);
+    && fnToString(constructor) === objStringValue;
 }


### PR DESCRIPTION
Calling toString on Object may cost a lot. It's much better to
have cached value for it.