### PR TITLE
Adds GitHub link to docs.

### DIFF
--- a/book.json
+++ b/book.json
@@ -3,11 +3,14 @@
   "structure": {
     "summary": "docs/README.md"
   },
-  "plugins": ["edit-link", "prism", "-highlight"],
+  "plugins": ["edit-link", "prism", "-highlight", "github"],
   "pluginsConfig": {
     "edit-link": {
       "base": "https://github.com/rackt/redux/tree/master",
       "label": "Edit This Page"
+    },
+    "github": {
+      "url": "https://github.com/rackt/redux/"
     }
   }
 }


### PR DESCRIPTION
I know this sounds a little bit ridiculous, however I struggle to find the link to
the repo on GitHub most of the time. This commit adds a little icon along with the
Twitter and co icons.

<img width="210" alt="screen shot 2015-10-26 at 11 03 27" src="https://cloud.githubusercontent.com/assets/14321/10726165/4bc24fd2-7bd1-11e5-8be4-a5876ab1501c.png">
