### PR TITLE
added reference to redux-mock-store in docs

### DIFF
--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -46,6 +46,7 @@ On this page we will only feature a few of them that the Redux maintainers have 
 * [redux-transducers](https://github.com/acdlite/redux-transducers) — Transducer utilities for Redux
 * [redux-immutablejs](https://github.com/indexiatech/redux-immutablejs) — Integration tools between Redux and [Immutable](https://github.com/facebook/immutable-js/)
 * [redux-tcomb](https://github.com/gcanti/redux-tcomb) — Immutable and type-checked state and actions for Redux
+* [redux-mock-store](https://github.com/arnaudbenard/redux-mock-store) - Mock redux store for testing your app
 
 ## Developer Tools
 

--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -62,7 +62,7 @@ describe('actions', () => {
 
 ### Async Action Creators
 
-For async action creators using [Redux Thunk](https://github.com/gaearon/redux-thunk) or other middleware, it’s best to completely mock the Redux store for tests. You can still use [`applyMiddleware()`](../api/applyMiddleware.md) with a mock store, as shown below. You can also use [nock](https://github.com/pgte/nock) to mock the HTTP requests.
+For async action creators using [Redux Thunk](https://github.com/gaearon/redux-thunk) or other middleware, it’s best to completely mock the Redux store for tests. You can still use [`applyMiddleware()`](../api/applyMiddleware.md) with a mock store, as shown below (you can find the following code in [redux-mock-store](https://github.com/arnaudbenard/redux-mock-store)). You can also use [nock](https://github.com/pgte/nock) to mock the HTTP requests.
 
 #### Example
 


### PR DESCRIPTION
Hi,

I discussed with @gaearon yesterday on [Twitter](https://twitter.com/dan_abramov/status/658689636227792896) about extracting the mock store logic into a separate package. The benefits are that we can test the library and don't need to copy paste code around when the mock example is updated in the docs.

Here's the module: https://github.com/arnaudbenard/redux-mock-store

Let me know if you want to append changes/more tests to the current implementation and reference the package in the redux docs.

Thank you ;)

