### PR TITLE
explore rollup builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,11 @@
     "isparta": "^3.0.3",
     "mocha": "^2.2.5",
     "rimraf": "^2.3.4",
-    "webpack": "^1.9.6"
+    "rollup": "^0.20.2",
+    "rollup-plugin-babel": "^1.0.0",
+    "uglifyjs": "^2.4.10",
+    "webpack": "^1.9.6",
+    "yargs": "^3.29.0"
   },
   "npmName": "redux",
   "npmFileMap": [

--- a/rollup.js
+++ b/rollup.js
@@ -1,0 +1,29 @@
+const rollup = require('rollup');
+const babel = require('rollup-plugin-babel');
+const fs = require('fs');
+const uglifyjs = require('uglifyjs');
+const argv = require('yargs').argv;
+
+rollup.rollup({
+  entry: './src/index.js',
+  plugins: [
+    babel({
+      exclude: 'node_modules/**'
+    })
+  ]
+}).then(function promiseHandler(bundle) {
+  const results = bundle.generate({
+    format: 'umd',
+    moduleName: 'Redux'
+  });
+  var code = results.code;
+
+  if (argv.production) {
+    code = code.replace('process.env.NODE_ENV', '"production"');
+    code = uglifyjs.minify(code, { fromString: true }).code;
+  }
+
+  fs.writeFileSync('./dist/redux.rollup.min.js', code);
+}).catch(function(err) {
+  console.error(err);
+});


### PR DESCRIPTION
ref: https://github.com/rackt/redux/issues/928

I could use rollup-plugin-replace instead of a simple code.replace but ... it's just an exploration.

Results are pretty cool. Didn't know that even if webpack bundling is better than browserify, it's still quite a cost.

But we don't gain THAT much after min + gz.

```
Webpack               |   Rollup
                      |
 22K redux.js         |  16K  redux.rollup.js
5,9K redux.js.gz      |  4,9K redux.rollup.js.gz
5,3K redux.min.js     |  3,9K redux.rollup.min.js
1,9K redux.min.js.gz  |  1,6K redux.rollup.min.js.gz
```