### PR TITLE
Add Shopping Cart to Docs (Examples.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ For PDF, ePub, and MOBI exports for offline reading, and instructions on how to 
 * [Async](http://rackt.github.io/redux/docs/introduction/Examples.html#async) ([source](https://github.com/rackt/redux/tree/master/examples/async))
 * [Universal](http://rackt.github.io/redux/docs/introduction/Examples.html#universal) ([source](https://github.com/rackt/redux/tree/master/examples/universal))
 * [Real World](http://rackt.github.io/redux/docs/introduction/Examples.html#real-world) ([source](https://github.com/rackt/redux/tree/master/examples/real-world))
+* [Shopping Cart](http://rackt.github.io/redux/docs/introduction/Examples.html#shopping-cart) ([source](https://github.com/rackt/redux/tree/master/examples/shopping-cart))
 
 If you’re new to the NPM ecosystem and have troubles getting a project up and running, or aren’t sure where to paste the gist above, check out [simplest-redux-example](https://github.com/jackielii/simplest-redux-example) that uses Redux together with React and Browserify.
 

--- a/docs/introduction/Examples.md
+++ b/docs/introduction/Examples.md
@@ -126,6 +126,33 @@ It covers:
 * Pagination
 * Routing
 
+## Shopping Cart
+
+Run the [Shopping Cart](https://github.com/rackt/redux/tree/master/examples/shopping-cart) example:
+
+```
+git clone https://github.com/rackt/redux.git
+
+cd redux/examples/shopping-cart
+npm install
+npm start
+
+open http://localhost:3000/
+```
+
+This is an example of idiomatic Redux development patterns.
+
+It covers:
+
+* Normalized state
+* Explicit entity ID tracking
+* Reducer composition
+* Queries defined alongside reducers
+* Example of rollback on failure
+* Safe conditional action dispatching
+* Using only [React Redux](https://github.com/rackt/react-redux) to bind action creators 
+* Conditional middleware (logging example)
+
 ## More Examples
 
 You can find more examples in [Awesome Redux](https://github.com/xgrommx/awesome-redux).


### PR DESCRIPTION
@gaearon I referenced some patterns you described in your PR, can you take a quick look?

![redux-shopping-cart-docs](https://cloud.githubusercontent.com/assets/1539088/10808221/483d82ba-7dbf-11e5-8e62-34267bbeab27.jpg)

With respect to the Examples in general, maybe we could replace "It covers:" with something like "Patterns:" and try to include links to relevant code in bullet points. Since many people use these examples as learning tools and references, the ability to scan and jump to patterns would be helpful.