### PR TITLE
adding backbone-redux to migration guide and ecosystem

### DIFF
--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -11,6 +11,7 @@ On this page we will only feature a few of them that the Redux maintainers have 
 * [react-redux](https://github.com/gaearon/react-redux) — React
 * [ng-redux](https://github.com/wbuchwalter/ng-redux) — Angular
 * [ng2-redux](https://github.com/wbuchwalter/ng2-redux) — Angular 2
+* [backbone-redux](https://github.com/redbooth/backbone-redux) — Backbone
 
 ## Middleware
 

--- a/docs/recipes/MigratingToRedux.md
+++ b/docs/recipes/MigratingToRedux.md
@@ -27,5 +27,5 @@ Your process will look like this:
 
 ## From Backbone
 
-Sorry, you’ll need to rewrite your model layer.  
-It’s way too different!
+Backbone's model layer is way too different compared with Redux one, so one possible option is to rewrite your app's model layer from scratch.   
+Or you can use [backone-redux](https://github.com/redbooth/backbone-redux) that will help you with migrating and/or using Backbone and Redux together.


### PR DESCRIPTION
Hi!

I've recently open-sourced [backbone-redux](https://github.com/redbooth/backbone-redux), a set of bindings that helps to keep your BB collections and redux tree in sync. 
It is used in production heavily now and helps us to gradually migrate our legacy Backbone/Marionette app to React + Redux without full rewrite. 
So I think that it maybe be useful for others to mention this option in the migration guide.