### PR TITLE
Wrap require(express) in express constructor in examples/server.js.

### DIFF
--- a/examples/async/server.js
+++ b/examples/async/server.js
@@ -3,7 +3,7 @@ var webpackDevMiddleware = require('webpack-dev-middleware');
 var webpackHotMiddleware = require('webpack-hot-middleware');
 var config = require('./webpack.config');
 
-var app = new require('express')();
+var app = new (require('express'))();
 var port = 3000;
 
 var compiler = webpack(config);

--- a/examples/counter/server.js
+++ b/examples/counter/server.js
@@ -3,7 +3,7 @@ var webpackDevMiddleware = require('webpack-dev-middleware');
 var webpackHotMiddleware = require('webpack-hot-middleware');
 var config = require('./webpack.config');
 
-var app = new require('express')();
+var app = new (require('express'))();
 var port = 3000;
 
 var compiler = webpack(config);

--- a/examples/real-world/server.js
+++ b/examples/real-world/server.js
@@ -3,7 +3,7 @@ var webpackDevMiddleware = require('webpack-dev-middleware');
 var webpackHotMiddleware = require('webpack-hot-middleware');
 var config = require('./webpack.config');
 
-var app = new require('express')();
+var app = new (require('express'))();
 var port = 3000;
 
 var compiler = webpack(config);

--- a/examples/shopping-cart/server.js
+++ b/examples/shopping-cart/server.js
@@ -3,7 +3,7 @@ var webpackDevMiddleware = require('webpack-dev-middleware');
 var webpackHotMiddleware = require('webpack-hot-middleware');
 var config = require('./webpack.config');
 
-var app = new require('express')();
+var app = new (require('express'))();
 var port = 3000;
 
 var compiler = webpack(config);

--- a/examples/todomvc/server.js
+++ b/examples/todomvc/server.js
@@ -3,7 +3,7 @@ var webpackDevMiddleware = require('webpack-dev-middleware');
 var webpackHotMiddleware = require('webpack-hot-middleware');
 var config = require('./webpack.config');
 
-var app = new require('express')();
+var app = new (require('express'))();
 var port = 3000;
 
 var compiler = webpack(config);

--- a/examples/todos-with-undo/server.js
+++ b/examples/todos-with-undo/server.js
@@ -3,7 +3,7 @@ var webpackDevMiddleware = require('webpack-dev-middleware');
 var webpackHotMiddleware = require('webpack-hot-middleware');
 var config = require('./webpack.config');
 
-var app = new require('express')();
+var app = new (require('express'))();
 var port = 3000;
 
 var compiler = webpack(config);


### PR DESCRIPTION
From: https://github.com/rackt/redux/issues/955

Wrapped each express constructor in parentheses to keep `express` from showing when running depcheck.  I did notice the examples have a lot of unused deps.  Should I go ahead and remove them?

Screenshot of some of the unused deps:
![image](https://cloud.githubusercontent.com/assets/2524280/10830968/07cdb43a-7e59-11e5-9462-4f2bb16689b9.png)
