### PR TITLE
descriptive syntax in all tests

### DIFF
--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -4,7 +4,7 @@ import { addTodo, dispatchInMiddle, throwError, unknownAction } from './helpers/
 import * as reducers from './helpers/reducers'
 
 describe('createStore', () => {
-  it('should expose the public API', () => {
+  it('exposes the public API', () => {
     const store = createStore(combineReducers(reducers))
     const methods = Object.keys(store)
 
@@ -15,7 +15,7 @@ describe('createStore', () => {
     expect(methods).toContain('replaceReducer')
   })
 
-  it('should require a reducer function', () => {
+  it('requires a reducer function', () => {
     expect(() =>
       createStore()
     ).toThrow()
@@ -33,7 +33,7 @@ describe('createStore', () => {
     ).toNotThrow()
   })
 
-  it('should pass the initial action and the initial state', () => {
+  it('passes the initial action and the initial state', () => {
     const store = createStore(reducers.todos, [
       {
         id: 1,
@@ -48,7 +48,7 @@ describe('createStore', () => {
     ])
   })
 
-  it('should apply the reducer to the previous state', () => {
+  it('applies the reducer to the previous state', () => {
     const store = createStore(reducers.todos)
     expect(store.getState()).toEqual([])
 
@@ -75,7 +75,7 @@ describe('createStore', () => {
     ])
   })
 
-  it('should apply the reducer to the initial state', () => {
+  it('applies the reducer to the initial state', () => {
     const store = createStore(reducers.todos, [
       {
         id: 1,
@@ -109,7 +109,7 @@ describe('createStore', () => {
     ])
   })
 
-  it('should preserve the state when replacing a reducer', () => {
+  it('preserves the state when replacing a reducer', () => {
     const store = createStore(reducers.todos)
     store.dispatch(addTodo('Hello'))
     store.dispatch(addTodo('World'))
@@ -188,7 +188,7 @@ describe('createStore', () => {
     ])
   })
 
-  it('should support multiple subscriptions', () => {
+  it('supports multiple subscriptions', () => {
     const store = createStore(reducers.todos)
     const listenerA = expect.createSpy(() => {})
     const listenerB = expect.createSpy(() => {})
@@ -235,7 +235,7 @@ describe('createStore', () => {
     expect(listenerB.calls.length).toBe(2)
   })
 
-  it('should only remove listener once when unsubscribe is called', () => {
+  it('only removes listener once when unsubscribe is called', () => {
     const store = createStore(reducers.todos)
     const listenerA = expect.createSpy(() => {})
     const listenerB = expect.createSpy(() => {})
@@ -251,7 +251,7 @@ describe('createStore', () => {
     expect(listenerB.calls.length).toBe(1)
   })
 
-  it('should only remove relevant listener when unsubscribe is called', () => {
+  it('only removes relevant listener when unsubscribe is called', () => {
     const store = createStore(reducers.todos)
     const listener = expect.createSpy(() => {})
 
@@ -265,7 +265,7 @@ describe('createStore', () => {
     expect(listener.calls.length).toBe(1)
   })
 
-  it('should support removing a subscription within a subscription', () => {
+  it('supports removing a subscription within a subscription', () => {
     const store = createStore(reducers.todos)
     const listenerA = expect.createSpy(() => {})
     const listenerB = expect.createSpy(() => {})
@@ -286,7 +286,7 @@ describe('createStore', () => {
     expect(listenerC.calls.length).toBe(2)
   })
 
-  it('should provide an up-to-date state when a subscriber is notified', done => {
+  it('provides an up-to-date state when a subscriber is notified', done => {
     const store = createStore(reducers.todos)
     store.subscribe(() => {
       expect(store.getState()).toEqual([
@@ -300,7 +300,7 @@ describe('createStore', () => {
     store.dispatch(addTodo('Hello'))
   })
 
-  it('should only accept plain object actions', () => {
+  it('only accepts plain object actions', () => {
     const store = createStore(reducers.todos)
     expect(() =>
       store.dispatch(unknownAction())
@@ -314,7 +314,7 @@ describe('createStore', () => {
     )
   })
 
-  it('should handle nested dispatches gracefully', () => {
+  it('handles nested dispatches gracefully', () => {
     function foo(state = 0, action) {
       return action.type === 'foo' ? 1 : state
     }
@@ -339,7 +339,7 @@ describe('createStore', () => {
     })
   })
 
-  it('should not allow dispatch() from within a reducer', () => {
+  it('does not allow dispatch() from within a reducer', () => {
     const store = createStore(reducers.dispatchInTheMiddleOfReducer)
 
     expect(() =>
@@ -358,21 +358,21 @@ describe('createStore', () => {
     ).toNotThrow()
   })
 
-  it('should throw if action type is missing', () => {
+  it('throws if action type is missing', () => {
     const store = createStore(reducers.todos)
     expect(() =>
       store.dispatch({})
     ).toThrow(/Actions may not have an undefined "type" property/)
   })
 
-  it('should throw if action type is undefined', () => {
+  it('throws if action type is undefined', () => {
     const store = createStore(reducers.todos)
     expect(() =>
       store.dispatch({ type: undefined })
     ).toThrow(/Actions may not have an undefined "type" property/)
   })
 
-  it('should not throw if action type is falsy', () => {
+  it('does not throw if action type is falsy', () => {
     const store = createStore(reducers.todos)
     expect(() =>
       store.dispatch({ type: false })

--- a/test/utils/applyMiddleware.spec.js
+++ b/test/utils/applyMiddleware.spec.js
@@ -29,7 +29,7 @@ describe('applyMiddleware', () => {
     expect(store.getState()).toEqual([ { id: 1, text: 'Use Redux' }, { id: 2, text: 'Flux FTW!' } ])
   })
 
-  it('should pass recursive dispatches through the middleware chain', () => {
+  it('passes recursive dispatches through the middleware chain', () => {
     function test(spyOnMethods) {
       return () => next => action => {
         spyOnMethods(action)

--- a/test/utils/bindActionCreators.spec.js
+++ b/test/utils/bindActionCreators.spec.js
@@ -47,7 +47,7 @@ describe('bindActionCreators', () => {
     )
   })
 
-  it('throwfor a null actionCreator', () => {
+  it('throws for a null actionCreator', () => {
     expect(() => {
       bindActionCreators(null, store.dispatch)
     }).toThrow(

--- a/test/utils/bindActionCreators.spec.js
+++ b/test/utils/bindActionCreators.spec.js
@@ -10,7 +10,7 @@ describe('bindActionCreators', () => {
     store = createStore(todos)
   })
 
-  it('should wrap the action creators with the dispatch function', () => {
+  it('wraps the action creators with the dispatch function', () => {
     const boundActionCreators = bindActionCreators(actionCreators, store.dispatch)
     expect(
       Object.keys(boundActionCreators)
@@ -27,7 +27,7 @@ describe('bindActionCreators', () => {
     ])
   })
 
-  it('should support wrapping a single function only', () => {
+  it('supports wrapping a single function only', () => {
     const actionCreator = actionCreators.addTodo
     const boundActionCreator = bindActionCreators(actionCreator, store.dispatch)
 
@@ -38,7 +38,7 @@ describe('bindActionCreators', () => {
     ])
   })
 
-  it('should throw for an undefined actionCreator', () => {
+  it('throws for an undefined actionCreator', () => {
     expect(() => {
       bindActionCreators(undefined, store.dispatch)
     }).toThrow(
@@ -47,7 +47,7 @@ describe('bindActionCreators', () => {
     )
   })
 
-  it('should throw for a null actionCreator', () => {
+  it('throwfor a null actionCreator', () => {
     expect(() => {
       bindActionCreators(null, store.dispatch)
     }).toThrow(
@@ -56,7 +56,7 @@ describe('bindActionCreators', () => {
     )
   })
 
-  it('should throw for a primitive actionCreator', () => {
+  it('throws for a primitive actionCreator', () => {
     expect(() => {
       bindActionCreators('string', store.dispatch)
     }).toThrow(

--- a/test/utils/combineReducers.spec.js
+++ b/test/utils/combineReducers.spec.js
@@ -4,7 +4,7 @@ import createStore, { ActionTypes } from '../../src/createStore'
 
 describe('Utils', () => {
   describe('combineReducers', () => {
-    it('should return a composite reducer that maps the state keys to given reducers', () => {
+    it('returns a composite reducer that maps the state keys to given reducers', () => {
       const reducer = combineReducers({
         counter: (state = 0, action) =>
         action.type === 'increment' ? state + 1 : state,
@@ -31,7 +31,7 @@ describe('Utils', () => {
       ).toEqual([ 'stack' ])
     })
 
-    it('should throw an error if a reducer returns undefined handling an action', () => {
+    it('throws an error if a reducer returns undefined handling an action', () => {
       const reducer = combineReducers({
         counter(state = 0, action) {
           switch (action && action.type) {
@@ -66,7 +66,7 @@ describe('Utils', () => {
       )
     })
 
-    it('should throw an error on first call if a reducer returns undefined initializing', () => {
+    it('throws an error on first call if a reducer returns undefined initializing', () => {
       const reducer = combineReducers({
         counter(state, action) {
           switch (action.type) {
@@ -84,7 +84,7 @@ describe('Utils', () => {
       )
     })
 
-    it('should catch error thrown in reducer when initializing and re-throw', () => {
+    it('catches error thrown in reducer when initializing and re-throw', () => {
       const reducer = combineReducers({
         throwingReducer() {
           throw new Error('Error thrown in reducer')
@@ -95,7 +95,7 @@ describe('Utils', () => {
       )
     })
 
-    it('should allow a symbol to be used as an action type', () => {
+    it('allows a symbol to be used as an action type', () => {
       const increment = Symbol('INCREMENT')
 
       const reducer = combineReducers({
@@ -112,7 +112,7 @@ describe('Utils', () => {
       expect(reducer({ counter: 0 }, { type: increment }).counter).toEqual(1)
     })
 
-    it('should maintain referential equality if the reducers it is combining do', () => {
+    it('maintains referential equality if the reducers it is combining do', () => {
       const reducer = combineReducers({
         child1(state = { }) {
           return state
@@ -129,7 +129,7 @@ describe('Utils', () => {
       expect(reducer(initialState, { type: 'FOO' })).toBe(initialState)
     })
 
-    it('should not have referential equality if one of the reducers changes something', () => {
+    it('does not have referential equality if one of the reducers changes something', () => {
       const reducer = combineReducers({
         child1(state = { }) {
           return state
@@ -151,7 +151,7 @@ describe('Utils', () => {
       expect(reducer(initialState, { type: 'increment' })).toNotBe(initialState)
     })
 
-    it('should throw an error on first call if a reducer attempts to handle a private action', () => {
+    it('throws an error on first call if a reducer attempts to handle a private action', () => {
       const reducer = combineReducers({
         counter(state, action) {
           switch (action.type) {
@@ -172,7 +172,7 @@ describe('Utils', () => {
       )
     })
 
-    it('should warn if no reducers are passed to combineReducers', () => {
+    it('warns if no reducers are passed to combineReducers', () => {
       const spy = expect.spyOn(console, 'error')
       const reducer = combineReducers({ })
       reducer({ })
@@ -182,7 +182,7 @@ describe('Utils', () => {
       spy.restore()
     })
 
-    it('should warn if input state object does not match state object returned by reducer', () => {
+    it('warns if input state object does not match state object returned by reducer', () => {
       const spy = expect.spyOn(console, 'error')
       const reducer = combineReducers({
         foo(state = { bar: 1 }) {

--- a/test/utils/isPlainObject.spec.js
+++ b/test/utils/isPlainObject.spec.js
@@ -3,7 +3,7 @@ import isPlainObject from '../../src/utils/isPlainObject'
 import vm from 'vm'
 
 describe('isPlainObject', () => {
-  it('should return true only if plain object', () => {
+  it('returns true only if plain object', () => {
     function Test() {
       this.prop = 1
     }

--- a/test/utils/mapValues.spec.js
+++ b/test/utils/mapValues.spec.js
@@ -2,7 +2,7 @@ import expect from 'expect'
 import mapValues from '../../src/utils/mapValues'
 
 describe('mapValues', () => {
-  it('should return object with mapped values', () => {
+  it('returns object with mapped values', () => {
     const test = {
       a: 'c',
       b: 'd'

--- a/test/utils/pick.spec.js
+++ b/test/utils/pick.spec.js
@@ -2,7 +2,7 @@ import expect from 'expect'
 import pick from '../../src/utils/pick'
 
 describe('pick', () => {
-  it('should return object with picked values', () => {
+  it('returns object with picked values', () => {
     const test = {
       name: 'lily',
       age: 20


### PR DESCRIPTION
hello,
this change unifies the test names to use descriptive syntax in all tests.
I found that in some places there were leftovers from the "should" syntax. :)