### PR TITLE
Add example app from basic tutorial

### DIFF
--- a/examples/tutorial-todo/.babelrc
+++ b/examples/tutorial-todo/.babelrc
@@ -1,0 +1,19 @@
+{
+  "stage": 2,
+  "env": {
+    "development": {
+      "plugins": [
+        "react-transform"
+      ],
+      "extra": {
+        "react-transform": {
+          "transforms": [{
+            "transform": "react-transform-hmr",
+            "imports": ["react"],
+            "locals":  ["module"]
+          }]
+        }
+      }
+    }
+  }
+}

--- a/examples/tutorial-todo/actions.js
+++ b/examples/tutorial-todo/actions.js
@@ -1,0 +1,33 @@
+/*
+ * action types
+ */
+
+export const ADD_TODO = 'ADD_TODO'
+export const COMPLETE_TODO = 'COMPLETE_TODO'
+export const SET_VISIBILITY_FILTER = 'SET_VISIBILITY_FILTER'
+
+/*
+ * other constants
+ */
+
+export const VisibilityFilters = {
+  SHOW_ALL: 'SHOW_ALL',
+  SHOW_COMPLETED: 'SHOW_COMPLETED',
+  SHOW_ACTIVE: 'SHOW_ACTIVE'
+}
+
+/*
+ * action creators
+ */
+
+export function addTodo(text) {
+  return { type: ADD_TODO, text }
+}
+
+export function completeTodo(index) {
+  return { type: COMPLETE_TODO, index }
+}
+
+export function setVisibilityFilter(filter) {
+  return { type: SET_VISIBILITY_FILTER, filter }
+}

--- a/examples/tutorial-todo/components/AddTodo.js
+++ b/examples/tutorial-todo/components/AddTodo.js
@@ -1,0 +1,25 @@
+import React, { Component, PropTypes } from 'react'
+
+export default class AddTodo extends Component {
+  render() {
+    return (
+      <div>
+        <input type='text' ref='input' />
+        <button onClick={(e) => this.handleClick(e)}>
+          Add
+        </button>
+      </div>
+    )
+  }
+
+  handleClick(e) {
+    const node = this.refs.input
+    const text = node.value.trim()
+    this.props.onAddClick(text)
+    node.value = ''
+  }
+}
+
+AddTodo.propTypes = {
+  onAddClick: PropTypes.func.isRequired
+}

--- a/examples/tutorial-todo/components/Footer.js
+++ b/examples/tutorial-todo/components/Footer.js
@@ -1,0 +1,42 @@
+import React, { Component, PropTypes } from 'react'
+
+export default class Footer extends Component {
+  renderFilter(filter, name) {
+    if (filter === this.props.filter) {
+      return name
+    }
+
+    return (
+      <a href='#' onClick={e => {
+        e.preventDefault()
+        this.props.onFilterChange(filter)
+      }}>
+        {name}
+      </a>
+    )
+  }
+
+  render() {
+    return (
+      <p>
+        Show:
+        {' '}
+        {this.renderFilter('SHOW_ALL', 'All')}
+        {', '}
+        {this.renderFilter('SHOW_COMPLETED', 'Completed')}
+        {', '}
+        {this.renderFilter('SHOW_ACTIVE', 'Active')}
+        .
+      </p>
+    )
+  }
+}
+
+Footer.propTypes = {
+  onFilterChange: PropTypes.func.isRequired,
+  filter: PropTypes.oneOf([
+    'SHOW_ALL',
+    'SHOW_COMPLETED',
+    'SHOW_ACTIVE'
+  ]).isRequired
+}

--- a/examples/tutorial-todo/components/Todo.js
+++ b/examples/tutorial-todo/components/Todo.js
@@ -1,0 +1,22 @@
+import React, { Component, PropTypes } from 'react'
+
+export default class Todo extends Component {
+  render() {
+    return (
+      <li
+        onClick={this.props.onClick}
+        style={{
+          textDecoration: this.props.completed ? 'line-through' : 'none',
+          cursor: this.props.completed ? 'default' : 'pointer'
+        }}>
+        {this.props.text}
+      </li>
+    )
+  }
+}
+
+Todo.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  text: PropTypes.string.isRequired,
+  completed: PropTypes.bool.isRequired
+}

--- a/examples/tutorial-todo/components/TodoList.js
+++ b/examples/tutorial-todo/components/TodoList.js
@@ -1,0 +1,24 @@
+import React, { Component, PropTypes } from 'react'
+import Todo from './Todo'
+
+export default class TodoList extends Component {
+  render() {
+    return (
+      <ul>
+        {this.props.todos.map((todo, index) =>
+          <Todo {...todo}
+                key={index}
+                onClick={() => this.props.onTodoClick(index)} />
+        )}
+      </ul>
+    )
+  }
+}
+
+TodoList.propTypes = {
+  onTodoClick: PropTypes.func.isRequired,
+  todos: PropTypes.arrayOf(PropTypes.shape({
+    text: PropTypes.string.isRequired,
+    completed: PropTypes.bool.isRequired
+  }).isRequired).isRequired
+}

--- a/examples/tutorial-todo/containers/App.js
+++ b/examples/tutorial-todo/containers/App.js
@@ -1,0 +1,66 @@
+import React, { Component, PropTypes } from 'react'
+import { connect } from 'react-redux'
+import { addTodo, completeTodo, setVisibilityFilter, VisibilityFilters } from '../actions'
+import AddTodo from '../components/AddTodo'
+import TodoList from '../components/TodoList'
+import Footer from '../components/Footer'
+
+class App extends Component {
+  render() {
+    // Injected by connect() call:
+    const { dispatch, visibleTodos, visibilityFilter } = this.props
+    return (
+      <div>
+        <AddTodo
+          onAddClick={text =>
+            dispatch(addTodo(text))
+          } />
+        <TodoList
+          todos={visibleTodos}
+          onTodoClick={index =>
+            dispatch(completeTodo(index))
+          } />
+        <Footer
+          filter={visibilityFilter}
+          onFilterChange={nextFilter =>
+            dispatch(setVisibilityFilter(nextFilter))
+          } />
+      </div>
+    )
+  }
+}
+
+App.propTypes = {
+  visibleTodos: PropTypes.arrayOf(PropTypes.shape({
+    text: PropTypes.string.isRequired,
+    completed: PropTypes.bool.isRequired
+  })),
+  visibilityFilter: PropTypes.oneOf([
+    'SHOW_ALL',
+    'SHOW_COMPLETED',
+    'SHOW_ACTIVE'
+  ]).isRequired
+}
+
+function selectTodos(todos, filter) {
+  switch (filter) {
+    case VisibilityFilters.SHOW_ALL:
+      return todos
+    case VisibilityFilters.SHOW_COMPLETED:
+      return todos.filter(todo => todo.completed)
+    case VisibilityFilters.SHOW_ACTIVE:
+      return todos.filter(todo => !todo.completed)
+  }
+}
+
+// Which props do we want to inject, given the global state?
+// Note: use https://github.com/faassen/reselect for better performance.
+function select(state) {
+  return {
+    visibleTodos: selectTodos(state.todos, state.visibilityFilter),
+    visibilityFilter: state.visibilityFilter
+  }
+}
+
+// Wrap the component to inject dispatch and state into it
+export default connect(select)(App)

--- a/examples/tutorial-todo/index.html
+++ b/examples/tutorial-todo/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redux TodoMVC example</title>
+  </head>
+  <body>
+    <div class="todoapp" id="root">
+    </div>
+    <script src="/static/bundle.js"></script>
+  </body>
+</html>

--- a/examples/tutorial-todo/index.js
+++ b/examples/tutorial-todo/index.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { render } from 'react-dom'
+import { createStore } from 'redux'
+import { Provider } from 'react-redux'
+import App from './containers/App'
+import todoApp from './reducers'
+
+let store = createStore(todoApp)
+
+let rootElement = document.getElementById('root')
+render(
+  <Provider store={store}>
+    <App />
+  </Provider>,
+  rootElement
+)

--- a/examples/tutorial-todo/package.json
+++ b/examples/tutorial-todo/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "redux-todomvc-example",
+  "version": "0.0.0",
+  "description": "Redux Basic Tutorial Todo example (see http://rackt.org/redux/docs/basics/ExampleTodoList.html)",
+  "scripts": {
+    "start": "node server.js",
+    "test": "NODE_ENV=test mocha --recursive --compilers js:babel-core/register --require ./test/setup.js",
+    "test:watch": "npm test -- --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rackt/redux.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/rackt/redux/issues"
+  },
+  "homepage": "http://rackt.github.io/redux",
+  "dependencies": {
+    "classnames": "^2.1.2",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
+    "react-redux": "^4.0.0",
+    "redux": "^3.0.0"
+  },
+  "devDependencies": {
+    "babel-core": "^5.6.18",
+    "babel-loader": "^5.1.4",
+    "babel-plugin-react-transform": "^1.1.0",
+    "expect": "^1.8.0",
+    "express": "^4.13.3",
+    "jsdom": "^5.6.1",
+    "mocha": "^2.2.5",
+    "node-libs-browser": "^0.5.2",
+    "raw-loader": "^0.5.1",
+    "react-addons-test-utils": "^0.14.0",
+    "react-transform-hmr": "^1.0.0",
+    "style-loader": "^0.12.3",
+    "todomvc-app-css": "^2.0.1",
+    "webpack": "^1.9.11",
+    "webpack-dev-middleware": "^1.2.0",
+    "webpack-hot-middleware": "^2.2.0"
+  }
+}

--- a/examples/tutorial-todo/reducers.js
+++ b/examples/tutorial-todo/reducers.js
@@ -1,0 +1,42 @@
+import { combineReducers } from 'redux'
+import { ADD_TODO, COMPLETE_TODO, SET_VISIBILITY_FILTER, VisibilityFilters } from './actions'
+const { SHOW_ALL } = VisibilityFilters
+
+function visibilityFilter(state = SHOW_ALL, action) {
+  switch (action.type) {
+    case SET_VISIBILITY_FILTER:
+      return action.filter
+    default:
+      return state
+  }
+}
+
+function todos(state = [], action) {
+  switch (action.type) {
+    case ADD_TODO:
+      return [
+        ...state,
+        {
+          text: action.text,
+          completed: false
+        }
+      ]
+    case COMPLETE_TODO:
+      return [
+        ...state.slice(0, action.index),
+        Object.assign({}, state[action.index], {
+          completed: true
+        }),
+        ...state.slice(action.index + 1)
+      ]
+    default:
+      return state
+  }
+}
+
+const todoApp = combineReducers({
+  visibilityFilter,
+  todos
+})
+
+export default todoApp

--- a/examples/tutorial-todo/server.js
+++ b/examples/tutorial-todo/server.js
@@ -1,0 +1,23 @@
+var webpack = require('webpack')
+var webpackDevMiddleware = require('webpack-dev-middleware')
+var webpackHotMiddleware = require('webpack-hot-middleware')
+var config = require('./webpack.config')
+
+var app = new (require('express'))()
+var port = 3000
+
+var compiler = webpack(config)
+app.use(webpackDevMiddleware(compiler, { noInfo: true, publicPath: config.output.publicPath }))
+app.use(webpackHotMiddleware(compiler))
+
+app.get("/", function(req, res) {
+  res.sendFile(__dirname + '/index.html')
+})
+
+app.listen(port, function(error) {
+  if (error) {
+    console.error(error)
+  } else {
+    console.info("==> 🌎  Listening on port %s. Open up http://localhost:%s/ in your browser.", port, port)
+  }
+})

--- a/examples/tutorial-todo/store/configureStore.js
+++ b/examples/tutorial-todo/store/configureStore.js
@@ -1,0 +1,16 @@
+import { createStore } from 'redux'
+import rootReducer from '../reducers'
+
+export default function configureStore(initialState) {
+  const store = createStore(rootReducer, initialState)
+
+  if (module.hot) {
+    // Enable Webpack hot module replacement for reducers
+    module.hot.accept('../reducers', () => {
+      const nextReducer = require('../reducers')
+      store.replaceReducer(nextReducer)
+    })
+  }
+
+  return store
+}

--- a/examples/tutorial-todo/webpack.config.js
+++ b/examples/tutorial-todo/webpack.config.js
@@ -1,0 +1,49 @@
+var path = require('path')
+var webpack = require('webpack')
+
+module.exports = {
+  devtool: 'cheap-module-eval-source-map',
+  entry: [
+    'webpack-hot-middleware/client',
+    './index'
+  ],
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: 'bundle.js',
+    publicPath: '/static/'
+  },
+  plugins: [
+    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoErrorsPlugin()
+  ],
+  module: {
+    loaders: [{
+      test: /\.js$/,
+      loaders: [ 'babel' ],
+      exclude: /node_modules/,
+      include: __dirname
+    }, {
+      test: /\.css?$/,
+      loaders: [ 'style', 'raw' ],
+      include: __dirname
+    }]
+  }
+}
+
+
+// When inside Redux repo, prefer src to compiled version.
+// You can safely delete these lines in your project.
+var reduxSrc = path.join(__dirname, '..', '..', 'src')
+var reduxNodeModules = path.join(__dirname, '..', '..', 'node_modules')
+var fs = require('fs')
+if (fs.existsSync(reduxSrc) && fs.existsSync(reduxNodeModules)) {
+  // Resolve Redux to source
+  module.exports.resolve = { alias: { 'redux': reduxSrc } }
+  // Compile Redux from source
+  module.exports.module.loaders.push({
+    test: /\.js$/,
+    loaders: [ 'babel' ],
+    include: reduxSrc
+  })
+}


### PR DESCRIPTION
This is just lifting the code from http://rackt.org/redux/docs/basics/ExampleTodoList.html and putting it into a readily executable example app.   Started with the basic infrastructure from the todomvc example and swapped in the source code from the basic tutorial example.

I believe it's helpful to be able to clone and run the tutorial example, not only for learning `redux` itself, but also because this is the example referenced in the `reselect` docs.

Did the work for myself in my fork, and just issuing this PR in case you think it would be helpful to have in the main repo.

Certainly no offense taken if you just want to close this.




