### PR TITLE
Setup Dockunit for more comprehensive continuous integration tests

### DIFF
--- a/Dockunit.json
+++ b/Dockunit.json
@@ -1,0 +1,45 @@
+{
+  "containers": [
+    {
+      "prettyName": "nodejs latest",
+      "image": "node:latest",
+      "testCommand": "npm test",
+      "beforeScripts": [
+        "npm install",
+        "npm install -g grunt-cli"
+      ]
+    },
+    {
+      "prettyName": "nodejs 5.0.0",
+      "image": "node:5.0.0",
+      "testCommand": "npm test",
+      "beforeScripts": [
+        "npm install"
+      ]
+    },
+    {
+      "prettyName": "nodejs 4.2.1",
+      "image": "dockunit/prebuilt-images:nodejs-mongodb-mocha-jasmine-4.2.1",
+      "testCommand": "npm test",
+      "beforeScripts": [
+        "npm install"
+      ]
+    },
+    {
+      "prettyName": "nodejs 0.12.7",
+      "image": "dockunit/prebuilt-images:nodejs-mongodb-mocha-jasmine-0.12.7",
+      "testCommand": "npm test",
+      "beforeScripts": [
+        "npm install"
+      ]
+    },
+    {
+      "prettyName": "nodejs 0.10.40",
+      "image": "dockunit/prebuilt-images:nodejs-mongodb-mocha-jasmine-0.10.40",
+      "testCommand": "npm test",
+      "beforeScripts": [
+        "npm install"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
[Dockunit](https://dockunit.io) is a continuous integration service built to be container based. It is super helpful because you can build and distribute your test environments from scratch and run tests locally with ease.

This PR tests Redux in Node.js latest, 5.0.0, 4.2.1, 0.12.7, and 0.10.40. The versions available on Dockunit are much more extensive than that of Travis CI. Incorporating Dockunit now will make it easier to test more complex environments in the future since it is Docker container based.

Assuming the PR is accepted, I'll send another with the Dockunit status badge for the README.md. You can see the [current Dockunit status of Redux here](https://dockunit.io/projects/tlovett1/redux).

Let me know what you guys think. Thanks!