### PR TITLE
composition can be seeded with multiple arguments

### DIFF
--- a/src/utils/compose.js
+++ b/src/utils/compose.js
@@ -7,8 +7,14 @@
  */
 export default function compose(...funcs) {
   return (...args) => {
-    return funcs.length ?
-      funcs.slice(0, -1).reduceRight((composed, f) => f(composed), funcs[funcs.length - 1](...args)) :
-      args[0]
+    if (funcs.length === 0) {
+      // We weren't given any functions, just return the first passed in arg.
+      return args[0];
+    }
+
+    const last = funcs[funcs.length - 1];
+    const rest = funcs.slice(0, -1);
+
+    return rest.reduceRight((composed, f) => f(composed), last(...args));
   }
 }

--- a/src/utils/compose.js
+++ b/src/utils/compose.js
@@ -9,12 +9,12 @@ export default function compose(...funcs) {
   return (...args) => {
     if (funcs.length === 0) {
       // We weren't given any functions, just return the first passed in arg.
-      return args[0];
+      return args[0]
     }
 
-    const last = funcs[funcs.length - 1];
-    const rest = funcs.slice(0, -1);
+    const last = funcs[funcs.length - 1]
+    const rest = funcs.slice(0, -1)
 
-    return rest.reduceRight((composed, f) => f(composed), last(...args));
+    return rest.reduceRight((composed, f) => f(composed), last(...args))
   }
 }

--- a/src/utils/compose.js
+++ b/src/utils/compose.js
@@ -6,7 +6,9 @@
  * left. For example, compose(f, g, h) is identical to arg => f(g(h(arg))).
  */
 export default function compose(...funcs) {
-  return (...args) => funcs.slice(0, -1).reduceRight((composed, f) =>
-    f(composed), funcs[funcs.length - 1](...args)
-  )
+  return (...args) => {
+    return funcs.length ?
+      funcs.slice(0, -1).reduceRight((composed, f) => f(composed), funcs[funcs.length - 1](...args)) :
+      args[0]
+  }
 }

--- a/src/utils/compose.js
+++ b/src/utils/compose.js
@@ -6,5 +6,7 @@
  * left. For example, compose(f, g, h) is identical to arg => f(g(h(arg))).
  */
 export default function compose(...funcs) {
-  return arg => funcs.reduceRight((composed, f) => f(composed), arg)
+  return (...args) => funcs.slice(0, -1).reduceRight((composed, f) =>
+    f(composed), funcs[funcs.length - 1](...args)
+  )
 }

--- a/test/utils/compose.spec.js
+++ b/test/utils/compose.spec.js
@@ -21,5 +21,11 @@ describe('Utils', () => {
       expect(compose(b, c, a)(final)('')).toBe('bca')
       expect(compose(c, a, b)(final)('')).toBe('cab')
     })
+
+    it('can be seeded with multiple arguments', () => {
+      const square = x => x * x
+      const add = (x, y) => x + y
+      expect(compose(square, add)(1, 2)).toBe(9)
+    })
   })
 })

--- a/test/utils/compose.spec.js
+++ b/test/utils/compose.spec.js
@@ -27,5 +27,11 @@ describe('Utils', () => {
       const add = (x, y) => x + y
       expect(compose(square, add)(1, 2)).toBe(9)
     })
+
+    it('returns the first given argument if given no functions', () => {
+      expect(compose()(1, 2)).toBe(1)
+      expect(compose()(3)).toBe(3)
+      expect(compose()()).toBe(undefined)
+    })
   })
 })


### PR DESCRIPTION
Related to https://github.com/rackt/redux/issues/632#issuecomment-157361578

This allows us to provide our composition with multiple arguments.

It does so by pulling off the last function from our list, calling it with the provided args, and using the result as the initialValue for reduceRight (which we then call on the remaining functions). Unfortunately, this does make our simple one liner a little more complex

Let me know if you see a cleaner approach.