### PR TITLE
Simplify applyMiddleware

### DIFF
--- a/src/utils/applyMiddleware.js
+++ b/src/utils/applyMiddleware.js
@@ -19,8 +19,8 @@ import compose from './compose'
 export default function applyMiddleware(...middlewares) {
   return (next) => (reducer, initialState) => {
     var store = next(reducer, initialState)
-    var dispatch = store.dispatch
     var chain = []
+    var dispatch
 
     var middlewareAPI = {
       getState: store.getState,


### PR DESCRIPTION
The assignment `dispatch = store.dispatch` is essentially a no-op as `dispatch` is assigned to the result of `compose(..chain)(store.dispatch)`. This pull request removes the assignment to simplify the code and avoid confusion as to what the actual value of `dispatch` is by the time the middleware invokes it (I had that question myself when reading the source).