### PR TITLE
Improving mockStore in WritingTests doc

### DIFF
--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -122,6 +122,8 @@ function mockStore(getState, expectedActions, done) {
   }
 
   function mockStoreWithoutMiddleware() {
+    let hasDoneBefore = false
+  
     return {
       getState() {
         return typeof getState === 'function' ?
@@ -130,16 +132,22 @@ function mockStore(getState, expectedActions, done) {
       },
 
       dispatch(action) {
+        if (hasDoneBefore) {
+          return
+        }
+      
         const expectedAction = expectedActions.shift()
 
         try {
           expect(action).toEqual(expectedAction)
           if (done && !expectedActions.length) {
             done()
+            hasDoneBefore = true
           }
           return action
         } catch (e) {
           done(e)
+          hasDoneBefore = true
         }
       }
     }


### PR DESCRIPTION
Currently `mockStore` in the doc [Writing Tests](http://rackt.org/redux/docs/recipes/WritingTests.html) would produce `done() called multiple times` error when assertion error occurs. It causes mocha to produce uninformative reports, instead of useful assertion errors:

```
1) async actions shall not pass:
     Error: done() called multiple times
      at Suite.<anonymous> (test.js:57:3)
      at Object.<anonymous> (test.js:56:1)
      at loader (node_modules/babel-core/node_modules/babel-register/lib/node.js:127:5)
      at Object.require.extensions.(anonymous function) [as .js] (node_modules/babel-core/node_modules/babel-register/lib/node.js:137:7)
      at Array.forEach (native)
      at node.js:961:3

  2) async actions shall not pass:
     Error: done() called multiple times
      at Suite.<anonymous> (test.js:57:3)
      at Object.<anonymous> (test.js:56:1)
      at loader (node_modules/babel-core/node_modules/babel-register/lib/node.js:127:5)
      at Object.require.extensions.(anonymous function) [as .js] (node_modules/babel-core/node_modules/babel-register/lib/node.js:137:7)
      at Array.forEach (native)
      at node.js:961:3
```

The detailed analysis and the minimal project to reproduce this bug is listed in this gist: https://gist.github.com/MrOrz/50bda5e23db2c39713e1

This pull request fixes the bug by turning `dispatch()` in `mockStore` into no-op after `done()` is called.
