### PR TITLE
Revert "Make gh-pages examples runnable"

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,4 @@
 **/dist/*
-**/static/*
 **/node_modules/*
 **/server.js
 **/webpack.config*.js

--- a/docs/introduction/Examples.md
+++ b/docs/introduction/Examples.md
@@ -5,7 +5,7 @@ Redux is distributed with a few examples in its [source code](https://github.com
 >##### Note on Copying
 >If you copy Redux examples outside their folders, you can delete some lines at the end of their `webpack.config.js` files. They follow a “You can safely delete these lines in your project.” comment.
 
-## [Counter](examples/counter)
+## Counter
 
 Run the [Counter](https://github.com/rackt/redux/tree/master/examples/counter) example:
 
@@ -24,7 +24,7 @@ It covers:
 * Basic Redux flow
 * Testing
 
-## [TodoMVC](examples/todomvc)
+## TodoMVC
 
 Run the [TodoMVC](https://github.com/rackt/redux/tree/master/examples/todomvc) example:
 
@@ -44,7 +44,7 @@ It covers:
 * Updating nested data
 * Testing
 
-## [Todos with Undo](examples/todos-with-undo)
+## Todos with Undo
 
 Run the [todos-with-undo](https://github.com/rackt/redux/tree/master/examples/todos-with-undo) example:
 
@@ -63,7 +63,7 @@ It covers:
 * Redux flow with two reducers
 * Undo/Redo functionality in Redux with [redux-undo](https://github.com/omnidan/redux-undo)
 
-## [Async](examples/async)
+## Async
 
 Run the [Async](https://github.com/rackt/redux/tree/master/examples/async) example:
 
@@ -103,7 +103,7 @@ It covers:
 * Prefetching state based on input and via asynchronous fetches.
 * Passing state from the server to the client
 
-## [Real World](examples/real-world)
+## Real World
 
 Run the [Real World](https://github.com/rackt/redux/tree/master/examples/real-world) example:
 
@@ -126,7 +126,7 @@ It covers:
 * Pagination
 * Routing
 
-## [Shopping Cart](examples/shopping-cart)
+## Shopping Cart
 
 Run the [Shopping Cart](https://github.com/rackt/redux/tree/master/examples/shopping-cart) example:
 

--- a/examples/async/index.html
+++ b/examples/async/index.html
@@ -6,6 +6,6 @@
   <body>
     <div id="root">
     </div>
-    <script src="./static/bundle.js"></script>
+    <script src="/static/bundle.js"></script>
   </body>
 </html>

--- a/examples/async/webpack.config.js
+++ b/examples/async/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     './index'
   ],
   output: {
-    path: path.join(__dirname, 'static'),
+    path: path.join(__dirname, 'dist'),
     filename: 'bundle.js',
     publicPath: '/static/'
   },

--- a/examples/counter/index.html
+++ b/examples/counter/index.html
@@ -6,6 +6,6 @@
   <body>
     <div id="root">
     </div>
-    <script src="./static/bundle.js"></script>
+    <script src="/static/bundle.js"></script>
   </body>
 </html>

--- a/examples/counter/webpack.config.js
+++ b/examples/counter/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     './index'
   ],
   output: {
-    path: path.join(__dirname, 'static'),
+    path: path.join(__dirname, 'dist'),
     filename: 'bundle.js',
     publicPath: '/static/'
   },

--- a/examples/real-world/index.html
+++ b/examples/real-world/index.html
@@ -6,6 +6,6 @@
   <body>
     <div id="root">
     </div>
-    <script src="./static/bundle.js"></script>
+    <script src="/static/bundle.js"></script>
   </body>
 </html>

--- a/examples/real-world/routes.js
+++ b/examples/real-world/routes.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Route, Redirect } from 'react-router'
+import { Route } from 'react-router'
 import App from './containers/App'
 import UserPage from './containers/UserPage'
 import RepoPage from './containers/RepoPage'
@@ -10,9 +10,5 @@ export default (
            component={RepoPage} />
     <Route path="/:login"
            component={UserPage} />
-
-    {/* needed to get github pages to work */}
-    <Redirect from="*" to="/" />
-
   </Route>
 )

--- a/examples/real-world/webpack.config.js
+++ b/examples/real-world/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     './index'
   ],
   output: {
-    path: path.join(__dirname, 'static'),
+    path: path.join(__dirname, 'dist'),
     filename: 'bundle.js',
     publicPath: '/static/'
   },

--- a/examples/shopping-cart/index.html
+++ b/examples/shopping-cart/index.html
@@ -6,6 +6,6 @@
   <body>
     <div id="root">
     </div>
-    <script src="./static/bundle.js"></script>
+    <script src="/static/bundle.js"></script>
   </body>
 </html>

--- a/examples/shopping-cart/webpack.config.js
+++ b/examples/shopping-cart/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     './index'
   ],
   output: {
-    path: path.join(__dirname, 'static'),
+    path: path.join(__dirname, 'dist'),
     filename: 'bundle.js',
     publicPath: '/static/'
   },

--- a/examples/todomvc/index.html
+++ b/examples/todomvc/index.html
@@ -6,6 +6,6 @@
   <body>
     <div class="todoapp" id="root">
     </div>
-    <script src="./static/bundle.js"></script>
+    <script src="/static/bundle.js"></script>
   </body>
 </html>

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "babel-core": "^5.6.18",
-    "babel-loader": "^5.4.0",
+    "babel-loader": "^5.1.4",
     "babel-plugin-react-transform": "^1.1.0",
     "expect": "^1.8.0",
     "express": "^4.13.3",
@@ -35,7 +35,7 @@
     "raw-loader": "^0.5.1",
     "react-addons-test-utils": "^0.14.0",
     "react-transform-hmr": "^1.0.0",
-    "style-loader": "^0.13.0",
+    "style-loader": "^0.12.3",
     "todomvc-app-css": "^2.0.1",
     "webpack": "^1.9.11",
     "webpack-dev-middleware": "^1.2.0",

--- a/examples/todomvc/webpack.config.js
+++ b/examples/todomvc/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     './index'
   ],
   output: {
-    path: path.join(__dirname, 'static'),
+    path: path.join(__dirname, 'dist'),
     filename: 'bundle.js',
     publicPath: '/static/'
   },

--- a/examples/todos-with-undo/index.html
+++ b/examples/todos-with-undo/index.html
@@ -6,6 +6,6 @@
   <body>
     <div id="root">
     </div>
-    <script src="./static/bundle.js"></script>
+    <script src="/static/bundle.js"></script>
   </body>
 </html>

--- a/examples/todos-with-undo/webpack.config.js
+++ b/examples/todos-with-undo/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     './index'
   ],
   output: {
-    path: path.join(__dirname, 'static'),
+    path: path.join(__dirname, 'dist'),
     filename: 'bundle.js',
     publicPath: '/static/'
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:umd": "webpack src/index.js dist/redux.js --config webpack.config.development.js",
     "build:umd:min": "webpack src/index.js dist/redux.min.js --config webpack.config.production.js",
     "build:examples": "babel-node examples/buildAll.js",
-    "build": "npm run build:lib && npm run build:umd && npm run build:umd:min && npm run build:examples",
+    "build": "npm run build:lib && npm run build:umd && npm run build:umd:min",
     "preversion": "npm run clean && npm run check",
     "version": "npm run build",
     "postversion": "git push && git push --tags && npm run clean && npm run docs:publish",


### PR DESCRIPTION
Reverts rackt/redux#1076 because it breaks the website.
None of the links on http://redux.js.org/docs/introduction/Examples.html work, and links like http://redux.js.org/examples/todomvc/ don't work either.