### PR TITLE
Fix docs/api/Store.md Example

### DIFF
--- a/docs/api/Store.md
+++ b/docs/api/Store.md
@@ -101,11 +101,11 @@ function select(state) {
   return state.some.deep.property
 }
 
-let currentValue
+let currentValue = select(store.getState())
 function handleChange() {
   let previousValue = currentValue
   currentValue = select(store.getState())
-  
+
   if (previousValue !== currentValue) {
     console.log('Some deep nested property changed from', previousValue, 'to', currentValue)
   }


### PR DESCRIPTION
Fix a bug in `docs/api/Store.md`'s Example.
`currentValue` was not initialized.