### PR TITLE
Docs: Added clarity re return value of store.dispatch

### DIFF
--- a/docs/api/Store.md
+++ b/docs/api/Store.md
@@ -47,7 +47,7 @@ The store’s reducing function will be called with the current [`getState()`](#
 
 #### Returns
 
-(Object<sup>†</sup>): The dispatched action.
+(Object<sup>†</sup>): The dispatched action or the return value of the middleware chain e.g. a Promise of the dispatch action object.
 
 #### Notes
 

--- a/docs/api/Store.md
+++ b/docs/api/Store.md
@@ -47,7 +47,7 @@ The store’s reducing function will be called with the current [`getState()`](#
 
 #### Returns
 
-(Object<sup>†</sup>): The dispatched action or the return value of the middleware chain e.g. a Promise of the dispatch action object.
+(Object<sup>†</sup>): The dispatched action (see notes).
 
 #### Notes
 


### PR DESCRIPTION
Added some more information about the return value of store.dispatch.

It should be the dispatched action but could also be the return value of the middleware chain, such as a promise of the dispatched action