### PR TITLE
Add Snowflake starter app

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ For PDF, ePub, and MOBI exports for offline reading, and instructions on how to 
 * [Universal](http://rackt.github.io/redux/docs/introduction/Examples.html#universal) ([source](https://github.com/rackt/redux/tree/master/examples/universal))
 * [Real World](http://rackt.github.io/redux/docs/introduction/Examples.html#real-world) ([source](https://github.com/rackt/redux/tree/master/examples/real-world))
 * [Shopping Cart](http://rackt.github.io/redux/docs/introduction/Examples.html#shopping-cart) ([source](https://github.com/rackt/redux/tree/master/examples/shopping-cart))
-
+* [Snowflake] (https://github.com/bartonhammond/snowflake) -  ReactNative, Redux, ReactRedux, Parse.com, Immutable, Jest (88%  coverage)- iOS & Android
+  
 If you’re new to the NPM ecosystem and have troubles getting a project up and running, or aren’t sure where to paste the gist above, check out [simplest-redux-example](https://github.com/jackielii/simplest-redux-example) that uses Redux together with React and Browserify.
 
 ### Discussion


### PR DESCRIPTION
I've released an 𝐎𝐩𝐞𝐧 𝐒𝐨𝐮𝐫𝐜𝐞 𝐒𝐨𝐟𝐭𝐰𝐚𝐫𝐞 project I call 𝑺𝒏𝒐𝒘𝒇𝒍𝒂𝒌𝒆. It's a javascript based application for both iOS and Android Devices. It is written using 𝗥𝗲𝗮𝗰𝘁𝗡𝗮𝘁𝗶𝘃𝗲, 𝗣𝗮𝗿𝘀𝗲.𝗰𝗼𝗺, 𝗥𝗲𝗱𝘂𝘅, 𝗝𝗲𝘀𝘁, 𝗜𝗺𝗺𝘂𝘁𝗮𝗯𝗹𝗲, and other technologies. This release it to help other developers learn how these 𝘁𝗲𝗰𝗵𝗻𝗼𝗹𝗼𝗴𝗶𝗲𝘀 𝘄𝗼𝗿𝗸 𝘀𝗲𝗮𝗺𝗹𝗲𝘀𝘀𝗹𝘆 𝘁𝗼𝗴𝗲𝘁𝗵𝗲𝗿 and take what used to be incredibly difficult to now be very achievable. I would consider it at this time as a "𝗯𝗼𝗶𝗹𝗲𝗿𝗽𝗹𝗮𝘁𝗲" or "𝘀𝘁𝗮𝗿𝘁𝗲𝗿" project that developers can learn from and use as their starting point.

[https://github.com/bartonhammond/snowflake](https://github.com/bartonhammond/snowflake)