### PR TITLE
Remove unnecessary arrow parens

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,8 @@
     "no-var": 0,
     "react/jsx-uses-react": 1,
     "react/jsx-no-undef": 2,
-    "react/wrap-multilines": 2
+    "react/wrap-multilines": 2,
+    "arrow-parens": [2, "as-needed"]
   },
   "plugins": [
     "react"

--- a/examples/buildAll.js
+++ b/examples/buildAll.js
@@ -6,7 +6,7 @@ import fs from 'fs'
 import path from 'path'
 import { spawnSync } from 'child_process'
 
-var exampleDirs = fs.readdirSync(__dirname).filter((file) => {
+var exampleDirs = fs.readdirSync(__dirname).filter(file => {
   return fs.statSync(path.join(__dirname, file)).isDirectory()
 })
 

--- a/examples/counter/test/actions/counter.spec.js
+++ b/examples/counter/test/actions/counter.spec.js
@@ -51,7 +51,7 @@ describe('actions', () => {
     expect(actions.decrement()).toEqual({ type: actions.DECREMENT_COUNTER })
   })
 
-  it('incrementIfOdd should create increment action', (done) => {
+  it('incrementIfOdd should create increment action', done => {
     const expectedActions = [
       { type: actions.INCREMENT_COUNTER }
     ]
@@ -59,14 +59,14 @@ describe('actions', () => {
     store.dispatch(actions.incrementIfOdd())
   })
 
-  it('incrementIfOdd shouldnt create increment action if counter is even', (done) => {
+  it('incrementIfOdd shouldnt create increment action if counter is even', done => {
     const expectedActions = []
     const store = mockStore({ counter: 2 }, expectedActions)
     store.dispatch(actions.incrementIfOdd())
     done()
   })
 
-  it('incrementAsync should create increment action', (done) => {
+  it('incrementAsync should create increment action', done => {
     const expectedActions = [
       { type: actions.INCREMENT_COUNTER }
     ]

--- a/examples/shopping-cart/containers/CartContainer.js
+++ b/examples/shopping-cart/containers/CartContainer.js
@@ -28,7 +28,7 @@ CartContainer.propTypes = {
   checkout: PropTypes.func.isRequired
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     products: getCartProducts(state),
     total: getTotal(state)

--- a/examples/testAll.js
+++ b/examples/testAll.js
@@ -6,7 +6,7 @@ import fs from 'fs'
 import path from 'path'
 import { spawnSync } from 'child_process'
 
-var exampleDirs = fs.readdirSync(__dirname).filter((file) => {
+var exampleDirs = fs.readdirSync(__dirname).filter(file => {
   return fs.statSync(path.join(__dirname, file)).isDirectory()
 })
 

--- a/examples/todomvc/components/TodoItem.js
+++ b/examples/todomvc/components/TodoItem.js
@@ -31,7 +31,7 @@ class TodoItem extends Component {
       element = (
         <TodoTextInput text={todo.text}
                        editing={this.state.editing}
-                       onSave={(text) => this.handleSave(todo.id, text)} />
+                       onSave={text => this.handleSave(todo.id, text)} />
       )
     } else {
       element = (

--- a/examples/todos-with-undo/components/AddTodo.js
+++ b/examples/todos-with-undo/components/AddTodo.js
@@ -14,7 +14,7 @@ export default class AddTodo extends Component {
   render() {
     return (
       <div>
-        <form onSubmit={(e) => this.handleSubmit(e)}>
+        <form onSubmit={e => this.handleSubmit(e)}>
           <input type="text" ref="input" />
           <button>
             Add

--- a/src/utils/applyMiddleware.js
+++ b/src/utils/applyMiddleware.js
@@ -17,14 +17,14 @@ import compose from './compose'
  * @returns {Function} A store enhancer applying the middleware.
  */
 export default function applyMiddleware(...middlewares) {
-  return (next) => (reducer, initialState) => {
+  return next => (reducer, initialState) => {
     var store = next(reducer, initialState)
     var dispatch = store.dispatch
     var chain = []
 
     var middlewareAPI = {
       getState: store.getState,
-      dispatch: (action) => dispatch(action)
+      dispatch: action => dispatch(action)
     }
     chain = middlewares.map(middleware => middleware(middlewareAPI))
     dispatch = compose(...chain)(store.dispatch)

--- a/src/utils/combineReducers.js
+++ b/src/utils/combineReducers.js
@@ -97,7 +97,7 @@ function assertReducerSanity(reducers) {
  */
 
 export default function combineReducers(reducers) {
-  var finalReducers = pick(reducers, (val) => typeof val === 'function')
+  var finalReducers = pick(reducers, val => typeof val === 'function')
   var sanityError
 
   try {

--- a/src/utils/isPlainObject.js
+++ b/src/utils/isPlainObject.js
@@ -1,4 +1,4 @@
-var fnToString = (fn) => Function.prototype.toString.call(fn)
+var fnToString = fn => Function.prototype.toString.call(fn)
 var objStringValue = fnToString(Object)
 
 /**


### PR DESCRIPTION
The codebase seems to not use parenthesis around a single variable arrow
function, except with the following. This forces the pattern.