### PR TITLE
Reducer Assertions when using createStore

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -1,5 +1,6 @@
 import isPlainObject from './utils/isPlainObject'
 import ActionTypes from './utils/actionTypes'
+import { assertStateNotUndefined, assertReducerSanity } from './utils/assertions'
 
 /**
  * Creates a Redux store that holds the state tree.
@@ -25,6 +26,7 @@ export default function createStore(reducer, initialState) {
   if (typeof reducer !== 'function') {
     throw new Error('Expected the reducer to be a function.')
   }
+  assertReducerSanity(reducer);
 
   var currentReducer = reducer
   var currentState = initialState
@@ -110,6 +112,7 @@ export default function createStore(reducer, initialState) {
     try {
       isDispatching = true
       currentState = currentReducer(currentState, action)
+      assertStateNotUndefined(currentState, action);
     } finally {
       isDispatching = false
     }

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -1,14 +1,5 @@
 import isPlainObject from './utils/isPlainObject'
-
-/**
- * These are private action types reserved by Redux.
- * For any unknown actions, you must return the current state.
- * If the current state is undefined, you must return the initial state.
- * Do not reference these action types directly in your code.
- */
-export var ActionTypes = {
-  INIT: '@@redux/INIT'
-}
+import ActionTypes from './utils/actionTypes'
 
 /**
  * Creates a Redux store that holds the state tree.

--- a/src/utils/actionTypes.js
+++ b/src/utils/actionTypes.js
@@ -1,0 +1,9 @@
+/**
+ * These are private action types reserved by Redux.
+ * For any unknown actions, you must return the current state.
+ * If the current state is undefined, you must return the initial state.
+ * Do not reference these action types directly in your code.
+ */
+export default {
+  INIT: '@@redux/INIT'
+}

--- a/src/utils/actionTypes.js
+++ b/src/utils/actionTypes.js
@@ -5,5 +5,6 @@
  * Do not reference these action types directly in your code.
  */
 export default {
-  INIT: '@@redux/INIT'
+  INIT: '@@redux/INIT',
+  PROBE: '@@redux/PROBE_UNKNOWN_ACTION_'
 }

--- a/src/utils/assertions.js
+++ b/src/utils/assertions.js
@@ -1,0 +1,41 @@
+import ActionTypes from './actionTypes'
+
+var quoted = name => name ? `"${name.toString()}"` : ''
+
+export function assertStateNotUndefined(state, action, name) {
+  var actionType = action && action.type
+  var actionName = quoted(actionType) || 'an action'
+
+  if (typeof state === 'undefined') {
+    throw new Error(
+      `Reducer ${quoted(name)} returned undefined handling ${actionName}. ` +
+      `To ignore an action, you must explicitly return the previous state.`
+    )
+  }
+}
+
+export function assertReducerSanity(reducer, name) {
+  var initialState = reducer(undefined, { type: ActionTypes.INIT })
+  name = quoted(name)
+
+  if (typeof initialState === 'undefined') {
+    throw new Error(
+      `Reducer ${name} returned undefined during initialization. ` +
+        `If the state passed to the reducer is undefined, you must ` +
+        `explicitly return the initial state. The initial state may ` +
+        `not be undefined.`
+    )
+  }
+
+  var type = '@@redux/PROBE_UNKNOWN_ACTION_' + Math.random().toString(36).substring(7).split('').join('.')
+  if (typeof reducer(undefined, { type }) === 'undefined') {
+    throw new Error(
+      `Reducer "${name}" returned undefined when probed with a random type. ` +
+        `Don't try to handle ${ActionTypes.INIT} or other actions in "redux/*" ` +
+        `namespace. They are considered private. Instead, you must return the ` +
+        `current state for any unknown actions, unless it is undefined, ` +
+        `in which case you must return the initial state, regardless of the ` +
+        `action type. The initial state may not be undefined.`
+    )
+  }
+}

--- a/src/utils/assertions.js
+++ b/src/utils/assertions.js
@@ -21,21 +21,21 @@ export function assertReducerSanity(reducer, name) {
   if (typeof initialState === 'undefined') {
     throw new Error(
       `Reducer ${name} returned undefined during initialization. ` +
-        `If the state passed to the reducer is undefined, you must ` +
-        `explicitly return the initial state. The initial state may ` +
-        `not be undefined.`
+      `If the state passed to the reducer is undefined, you must ` +
+      `explicitly return the initial state. The initial state may ` +
+      `not be undefined.`
     )
   }
 
   var type = '@@redux/PROBE_UNKNOWN_ACTION_' + Math.random().toString(36).substring(7).split('').join('.')
   if (typeof reducer(undefined, { type }) === 'undefined') {
     throw new Error(
-      `Reducer "${name}" returned undefined when probed with a random type. ` +
-        `Don't try to handle ${ActionTypes.INIT} or other actions in "redux/*" ` +
-        `namespace. They are considered private. Instead, you must return the ` +
-        `current state for any unknown actions, unless it is undefined, ` +
-        `in which case you must return the initial state, regardless of the ` +
-        `action type. The initial state may not be undefined.`
+      `Reducer ${name} returned undefined when probed with a random type. ` +
+      `Don't try to handle ${ActionTypes.INIT} or other actions in "redux/*" ` +
+      `namespace. They are considered private. Instead, you must return the ` +
+      `current state for any unknown actions, unless it is undefined, ` +
+      `in which case you must return the initial state, regardless of the ` +
+      `action type. The initial state may not be undefined.`
     )
   }
 }

--- a/src/utils/assertions.js
+++ b/src/utils/assertions.js
@@ -27,7 +27,7 @@ export function assertReducerSanity(reducer, name) {
     )
   }
 
-  var type = '@@redux/PROBE_UNKNOWN_ACTION_' + Math.random().toString(36).substring(7).split('').join('.')
+  var type = ActionTypes.PROBE + Math.random().toString(36).substring(7).split('').join('.')
   if (typeof reducer(undefined, { type }) === 'undefined') {
     throw new Error(
       `Reducer ${name} returned undefined when probed with a random type. ` +

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -2,6 +2,7 @@ import expect from 'expect'
 import { createStore, combineReducers } from '../src/index'
 import { addTodo, dispatchInMiddle, throwError, unknownAction } from './helpers/actionCreators'
 import * as reducers from './helpers/reducers'
+import ActionTypes from '../src/utils/actionTypes'
 
 describe('createStore', () => {
   it('exposes the public API', () => {
@@ -29,7 +30,7 @@ describe('createStore', () => {
     ).toThrow()
 
     expect(() =>
-      createStore(() => {})
+      createStore(() => ({}))
     ).toNotThrow()
   })
 
@@ -90,7 +91,7 @@ describe('createStore', () => {
     ])
 
     store.dispatch(unknownAction())
-    expect(store.getState()).toEqual([ 
+    expect(store.getState()).toEqual([
       {
         id: 1,
         text: 'Hello'
@@ -140,11 +141,11 @@ describe('createStore', () => {
       {
         id: 3,
         text: 'Perhaps'
-      }, 
+      },
       {
         id: 1,
         text: 'Hello'
-      }, 
+      },
       {
         id: 2,
         text: 'World'
@@ -156,11 +157,11 @@ describe('createStore', () => {
       {
         id: 3,
         text: 'Perhaps'
-      }, 
+      },
       {
         id: 1,
         text: 'Hello'
-      }, 
+      },
       {
         id: 2,
         text: 'World'
@@ -172,15 +173,15 @@ describe('createStore', () => {
       {
         id: 3,
         text: 'Perhaps'
-      }, 
+      },
       {
         id: 1,
         text: 'Hello'
-      }, 
+      },
       {
         id: 2,
         text: 'World'
-      }, 
+      },
       {
         id: 4,
         text: 'Surely'
@@ -386,5 +387,47 @@ describe('createStore', () => {
     expect(() =>
       store.dispatch({ type: '' })
     ).toNotThrow()
+  })
+
+  it('throws an error if reducer returns undefined handling an action', () => {
+    const store = createStore((state = 0, action) => {
+      switch (action && action.type) {
+        case 'whatever':
+          return undefined
+        default:
+          return state
+      }
+    })
+
+    expect(
+      () => store.dispatch({ type: 'whatever' })
+    ).toThrow(
+    /"whatever"/
+    )
+  })
+
+  it('throws an error on first call if reducer returns undefined initializing', () => {
+    expect(
+      () => createStore(() => {})
+    ).toThrow(
+      /initialization/
+    )
+  })
+
+  it('throws an error on if reducer attempts to handle a private action', () => {
+    const reducer = (state, action) => {
+      switch (action.type) {
+        // Never do this in your code:
+        case ActionTypes.INIT:
+          return 0
+        default:
+          return undefined
+      }
+    }
+    expect(
+      () => createStore(reducer)
+    ).toThrow(
+      /private/
+    )
   })
 })

--- a/test/utils/combineReducers.spec.js
+++ b/test/utils/combineReducers.spec.js
@@ -1,6 +1,7 @@
 import expect from 'expect'
 import { combineReducers } from '../../src'
-import createStore, { ActionTypes } from '../../src/createStore'
+import createStore from '../../src/createStore'
+import ActionTypes from '../../src/utils/actionTypes'
 
 describe('Utils', () => {
   describe('combineReducers', () => {


### PR DESCRIPTION
This extracts the two generic reducer assertions (reducer sanity and never returning undefined) from `combineReducers`, so that they can be used with `createStore`'s reducer.