### PR TITLE
Fix nock response to return a body

### DIFF
--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -120,7 +120,7 @@ describe('async actions', () => {
   it('creates FETCH_TODOS_SUCCESS when fetching todos has been done', (done) => {
     nock('http://example.com/')
       .get('/todos')
-      .reply(200, { todos: ['do something'] })
+      .reply(200, { body: { todos: ['do something'] }})
 
     const expectedActions = [
       { type: types.FETCH_TODOS_REQUEST },


### PR DESCRIPTION
-The thunk action 'fetchTodos' resolves the promise and then passes json.body to the fetchTodosSuccess. 
-The bug was returning 'undefined' for json.body because the mock response was not returning a body