### PR TITLE
Remove defined but not used imported libraries

### DIFF
--- a/docs/recipes/WritingTests.md
+++ b/docs/recipes/WritingTests.md
@@ -101,8 +101,6 @@ export function fetchTodos() {
 can be tested like:
 
 ```js
-import expect from 'expect'
-import { applyMiddleware } from 'redux'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import * as actions from '../../actions/counter'


### PR DESCRIPTION
-Since expect is being used inside of the 'redux-mock-store', there is no longer a need to import expect in this example 
-The same is applicable to 'applyMiddleware', because it's being imported in the 'redux-mock-store'