### PR TITLE
(Help needed!) Change the router to redux-simple-router

### DIFF
--- a/examples/real-world/containers/App.js
+++ b/examples/real-world/containers/App.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
-import { pushState } from 'redux-router'
+import { pushPath } from 'redux-simple-router'
 import Explore from '../components/Explore'
 import { resetErrorMessage } from '../actions'
 
@@ -17,7 +17,7 @@ class App extends Component {
   }
 
   handleChange(nextValue) {
-    this.props.pushState(null, `/${nextValue}`)
+    this.props.pushPath(`/${nextValue}`)
   }
 
   renderErrorMessage() {
@@ -56,7 +56,7 @@ App.propTypes = {
   // Injected by React Redux
   errorMessage: PropTypes.string,
   resetErrorMessage: PropTypes.func.isRequired,
-  pushState: PropTypes.func.isRequired,
+  pushPath: PropTypes.func.isRequired,
   inputValue: PropTypes.string.isRequired,
   // Injected by React Router
   children: PropTypes.node
@@ -65,11 +65,11 @@ App.propTypes = {
 function mapStateToProps(state) {
   return {
     errorMessage: state.errorMessage,
-    inputValue: state.router.location.pathname.substring(1)
+    inputValue: state.routing.path.substring(1)
   }
 }
 
 export default connect(mapStateToProps, {
   resetErrorMessage,
-  pushState
+  pushPath
 })(App)

--- a/examples/real-world/containers/RepoPage.js
+++ b/examples/real-world/containers/RepoPage.js
@@ -72,8 +72,8 @@ RepoPage.propTypes = {
   loadStargazers: PropTypes.func.isRequired
 }
 
-function mapStateToProps(state) {
-  const [ login, name ] = state.routing.path.split('/').slice(1)
+function mapStateToProps(state, props) {
+  const { login, name } = props.params
   const {
     pagination: { stargazersByRepo },
     entities: { users, repos }

--- a/examples/real-world/containers/RepoPage.js
+++ b/examples/real-world/containers/RepoPage.js
@@ -73,7 +73,7 @@ RepoPage.propTypes = {
 }
 
 function mapStateToProps(state) {
-  const { login, name } = state.router.params
+  const [ login, name ] = state.routing.path.split('/').slice(1)
   const {
     pagination: { stargazersByRepo },
     entities: { users, repos }

--- a/examples/real-world/containers/Root.dev.js
+++ b/examples/real-world/containers/Root.dev.js
@@ -1,15 +1,18 @@
 import React, { Component, PropTypes } from 'react'
 import { Provider } from 'react-redux'
-import { ReduxRouter } from 'redux-router'
+import { Router } from 'react-router'
+import routes from '../routes'
 import DevTools from './DevTools'
 
 export default class Root extends Component {
   render() {
-    const { store } = this.props
+    const { store, history } = this.props
     return (
       <Provider store={store}>
         <div>
-          <ReduxRouter />
+          <Router history={history}>
+            {routes}
+          </Router>
           <DevTools />
         </div>
       </Provider>

--- a/examples/real-world/containers/Root.prod.js
+++ b/examples/real-world/containers/Root.prod.js
@@ -1,13 +1,16 @@
 import React, { Component, PropTypes } from 'react'
 import { Provider } from 'react-redux'
-import { ReduxRouter } from 'redux-router'
+import { Router } from 'react-router'
+import routes from '../routes'
 
 export default class Root extends Component {
   render() {
-    const { store } = this.props
+    const { store, history } = this.props
     return (
       <Provider store={store}>
-        <ReduxRouter />
+        <Router history={history}>
+          {routes}
+        </Router>
       </Provider>
     )
   }

--- a/examples/real-world/containers/UserPage.js
+++ b/examples/real-world/containers/UserPage.js
@@ -73,7 +73,7 @@ UserPage.propTypes = {
 }
 
 function mapStateToProps(state) {
-  const { login } = state.router.params
+  const login = state.routing.path.split('/')[1]
   const {
     pagination: { starredByUser },
     entities: { users, repos }

--- a/examples/real-world/containers/UserPage.js
+++ b/examples/real-world/containers/UserPage.js
@@ -72,8 +72,8 @@ UserPage.propTypes = {
   loadStarred: PropTypes.func.isRequired
 }
 
-function mapStateToProps(state) {
-  const login = state.routing.path.split('/')[1]
+function mapStateToProps(state, props) {
+  const { login } = props.params
   const {
     pagination: { starredByUser },
     entities: { users, repos }

--- a/examples/real-world/index.js
+++ b/examples/real-world/index.js
@@ -3,10 +3,15 @@ import React from 'react'
 import { render } from 'react-dom'
 import Root from './containers/Root'
 import configureStore from './store/configureStore'
+import { createHistory } from 'history'
+import { syncReduxAndRouter } from 'redux-simple-router'
 
 const store = configureStore()
+const history = createHistory()
+
+syncReduxAndRouter(history, store)
 
 render(
-  <Root store={store} />,
+  <Root store={store} history={history} />,
   document.getElementById('root')
 )

--- a/examples/real-world/package.json
+++ b/examples/real-world/package.json
@@ -26,7 +26,7 @@
     "react-router": "^1.0.3",
     "redux": "^3.0.0",
     "redux-logger": "^2.0.2",
-    "redux-router": "^1.0.0-beta3",
+    "redux-simple-router": "^1.0.0",
     "redux-thunk": "^0.1.0"
   },
   "devDependencies": {

--- a/examples/real-world/reducers/index.js
+++ b/examples/real-world/reducers/index.js
@@ -1,7 +1,7 @@
 import * as ActionTypes from '../actions'
 import merge from 'lodash/object/merge'
 import paginate from './paginate'
-import { routerStateReducer as router } from 'redux-router'
+import { routeReducer as routing } from 'redux-simple-router'
 import { combineReducers } from 'redux'
 
 // Updates an entity cache in response to any action with response.entities.
@@ -50,7 +50,7 @@ const rootReducer = combineReducers({
   entities,
   pagination,
   errorMessage,
-  router
+  routing
 })
 
 export default rootReducer

--- a/examples/real-world/store/configureStore.dev.js
+++ b/examples/real-world/store/configureStore.dev.js
@@ -1,8 +1,5 @@
 import { createStore, applyMiddleware, compose } from 'redux'
-import { reduxReactRouter } from 'redux-router'
 import DevTools from '../containers/DevTools'
-import createHistory from 'history/lib/createBrowserHistory'
-import routes from '../routes'
 import thunk from 'redux-thunk'
 import api from '../middleware/api'
 import createLogger from 'redux-logger'
@@ -10,7 +7,6 @@ import rootReducer from '../reducers'
 
 const finalCreateStore = compose(
   applyMiddleware(thunk, api),
-  reduxReactRouter({ routes, createHistory }),
   applyMiddleware(createLogger()),
   DevTools.instrument()
 )(createStore)

--- a/examples/real-world/store/configureStore.prod.js
+++ b/examples/real-world/store/configureStore.prod.js
@@ -1,14 +1,10 @@
 import { createStore, applyMiddleware, compose } from 'redux'
-import { reduxReactRouter } from 'redux-router'
-import createHistory from 'history/lib/createBrowserHistory'
-import routes from '../routes'
 import thunk from 'redux-thunk'
 import api from '../middleware/api'
 import rootReducer from '../reducers'
 
 const finalCreateStore = compose(
   applyMiddleware(thunk, api),
-  reduxReactRouter({ routes, createHistory })
 )(createStore)
 
 export default function configureStore(initialState) {


### PR DESCRIPTION
I decided to learn more about React/Redux/... a few days ago and ran into issue #1143 while reading about react-router. As @gaearon was talking about migrating the Real World example to [redux-simple-router](https://github.com/jlongster/redux-simple-router) I thought it could be a nice way to experiment with routing and decided to give it a shot.

I did that quickly this morning and I'm not really familiar with react-router yet so just let me know what you think about it and if it's decent enough to be contributed or not.