### PR TITLE
Set listener scope

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -123,7 +123,7 @@ export default function createStore(reducer, initialState) {
       isDispatching = false
     }
 
-    listeners.slice().forEach(listener => listener())
+    listeners.slice().forEach(listener => listener({ getState }))
     return action
   }
 


### PR DESCRIPTION
How about explicitly define a scope to listener instead implicitly using **store**? (anyways you could use both with this update).