### PR TITLE
Make App container clearer on counter example

### DIFF
--- a/examples/counter/components/Counter.js
+++ b/examples/counter/components/Counter.js
@@ -4,9 +4,8 @@ class Counter extends Component {
   render() {
     const { increment, incrementIfOdd, incrementAsync, decrement, counter } = this.props
     return (
-      <p>
+      <span>
         Clicked: {counter} times
-        {' '}
         <button onClick={increment}>+</button>
         {' '}
         <button onClick={decrement}>-</button>
@@ -14,7 +13,7 @@ class Counter extends Component {
         <button onClick={incrementIfOdd}>Increment if odd</button>
         {' '}
         <button onClick={() => incrementAsync()}>Increment async</button>
-      </p>
+      </span>
     )
   }
 }

--- a/examples/counter/containers/App.js
+++ b/examples/counter/containers/App.js
@@ -1,16 +1,10 @@
-import { bindActionCreators } from 'redux'
-import { connect } from 'react-redux'
-import Counter from '../components/Counter'
-import * as CounterActions from '../actions/counter'
+import React, { Component } from 'react'
+import CounterContainer from './CounterContainer'
 
-function mapStateToProps(state) {
-  return {
-    counter: state.counter
+export default class App extends Component {
+  render() {
+    return (
+      <h1>Counter: <CounterContainer /></h1>
+    )
   }
 }
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators(CounterActions, dispatch)
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(Counter)

--- a/examples/counter/containers/CounterContainer.js
+++ b/examples/counter/containers/CounterContainer.js
@@ -1,0 +1,18 @@
+import { bindActionCreators } from 'redux'
+import { connect } from 'react-redux'
+import Counter from '../components/Counter'
+import * as CounterActions from '../actions/counter'
+
+function mapStateToProps(state) {
+  // Pick only the state that matters to Counter component
+  return {
+    counter: state.counter
+  }
+}
+
+function mapDispatchToProps(dispatch) {
+  // Wrap dispatch between the Counter action creators, so we can call them directly
+  return bindActionCreators(CounterActions, dispatch)
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Counter)

--- a/examples/counter/test/components/Counter.spec.js
+++ b/examples/counter/test/components/Counter.spec.js
@@ -15,14 +15,14 @@ function setup() {
     component: component,
     actions: actions,
     buttons: TestUtils.scryRenderedDOMComponentsWithTag(component, 'button'),
-    p: TestUtils.findRenderedDOMComponentWithTag(component, 'p')
+    span: TestUtils.findRenderedDOMComponentWithTag(component, 'span')
   }
 }
 
 describe('Counter component', () => {
   it('should display count', () => {
-    const { p } = setup()
-    expect(p.textContent).toMatch(/^Clicked: 1 times/)
+    const { span } = setup()
+    expect(span.textContent).toMatch(/^Clicked: 1 times/)
   })
 
   it('first button should call increment', () => {

--- a/examples/counter/test/containers/App.spec.js
+++ b/examples/counter/test/containers/App.spec.js
@@ -15,39 +15,39 @@ function setup(initialState) {
   return {
     app: app,
     buttons: TestUtils.scryRenderedDOMComponentsWithTag(app, 'button'),
-    p: TestUtils.findRenderedDOMComponentWithTag(app, 'p')
+    span: TestUtils.findRenderedDOMComponentWithTag(app, 'span')
   }
 }
 
 describe('containers', () => {
   describe('App', () => {
     it('should display initial count', () => {
-      const { p } = setup()
-      expect(p.textContent).toMatch(/^Clicked: 0 times/)
+      const { span } = setup()
+      expect(span.textContent).toMatch(/^Clicked: 0 times/)
     })
 
     it('should display updated count after increment button click', () => {
-      const { buttons, p } = setup()
+      const { buttons, span } = setup()
       TestUtils.Simulate.click(buttons[0])
-      expect(p.textContent).toMatch(/^Clicked: 1 times/)
+      expect(span.textContent).toMatch(/^Clicked: 1 times/)
     })
 
     it('should display updated count after decrement button click', () => {
-      const { buttons, p } = setup()
+      const { buttons, span } = setup()
       TestUtils.Simulate.click(buttons[1])
-      expect(p.textContent).toMatch(/^Clicked: -1 times/)
+      expect(span.textContent).toMatch(/^Clicked: -1 times/)
     })
 
     it('shouldnt change if even and if odd button clicked', () => {
-      const { buttons, p } = setup()
+      const { buttons, span } = setup()
       TestUtils.Simulate.click(buttons[2])
-      expect(p.textContent).toMatch(/^Clicked: 0 times/)
+      expect(span.textContent).toMatch(/^Clicked: 0 times/)
     })
 
     it('should change if odd and if odd button clicked', () => {
-      const { buttons, p } = setup({ counter: 1 })
+      const { buttons, span } = setup({ counter: 1 })
       TestUtils.Simulate.click(buttons[2])
-      expect(p.textContent).toMatch(/^Clicked: 2 times/)
+      expect(span.textContent).toMatch(/^Clicked: 2 times/)
     })
   })
 })


### PR DESCRIPTION
* Instead of exporting the connected Counter directly, create a visible wrapper to improve readability
* Add some docstrings to make connect params clearer on first read.

The motivation was trying to read this code but failing on first try, because I (and a friend of mine). couldn't understand what was happening here without writing this down.