### PR TITLE
Remove unnecessary arguments

### DIFF
--- a/examples/todomvc/test/actions/todos.spec.js
+++ b/examples/todomvc/test/actions/todos.spec.js
@@ -39,7 +39,7 @@ describe('todo actions', () => {
   })
 
   it('clearCompleted should create CLEAR_COMPLETED action', () => {
-    expect(actions.clearCompleted('Use Redux')).toEqual({
+    expect(actions.clearCompleted()).toEqual({
       type: types.CLEAR_COMPLETED
     })
   })


### PR DESCRIPTION
`actions.clearCompleted()` doesn't accept any arguments.