### PR TITLE
Changing Stateless components to default to function syntax instead of classes syntex

### DIFF
--- a/examples/async/components/Picker.js
+++ b/examples/async/components/Picker.js
@@ -1,7 +1,7 @@
-import React, { Component, PropTypes } from 'react'
+import React, { PropTypes } from 'react'
 /* Changing the syntax for Stateless function in more functional syntax */
-const Picker = ({value, onChange, options}) => {
-    return (
+const Picker = ({ value, onChange, options }) => {
+  return (
       <span>
         <h1>{value}</h1>
         <select onChange={e => onChange(e.target.value)}
@@ -23,5 +23,4 @@ Picker.propTypes = {
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired
 }
-
-export default Picker;
+export default Picker

--- a/examples/async/components/Picker.js
+++ b/examples/async/components/Picker.js
@@ -1,9 +1,6 @@
 import React, { Component, PropTypes } from 'react'
-
-export default class Picker extends Component {
-  render() {
-    const { value, onChange, options } = this.props
-
+/* Changing the syntax for Stateless function in more functional syntax */
+const Picker = ({value, onChange, options}) => {
     return (
       <span>
         <h1>{value}</h1>
@@ -17,7 +14,6 @@ export default class Picker extends Component {
         </select>
       </span>
     )
-  }
 }
 
 Picker.propTypes = {
@@ -27,3 +23,5 @@ Picker.propTypes = {
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired
 }
+
+export default Picker;

--- a/examples/async/components/Posts.js
+++ b/examples/async/components/Posts.js
@@ -1,7 +1,7 @@
-import React, { PropTypes, Component } from 'react'
+import React, { PropTypes } from 'react'
 
-const Posts = ({props}) => {
-    return (
+const Posts = ( props ) => {
+  return (
       <ul>
         {props.posts.map((post, i) =>
           <li key={i}>{post.title}</li>

--- a/examples/async/components/Posts.js
+++ b/examples/async/components/Posts.js
@@ -1,17 +1,16 @@
 import React, { PropTypes, Component } from 'react'
 
-export default class Posts extends Component {
-  render() {
+const Posts = ({props}) => {
     return (
       <ul>
-        {this.props.posts.map((post, i) =>
+        {props.posts.map((post, i) =>
           <li key={i}>{post.title}</li>
         )}
       </ul>
     )
-  }
 }
-
 Posts.propTypes = {
   posts: PropTypes.array.isRequired
 }
+
+export default Posts

--- a/examples/counter/components/Counter.js
+++ b/examples/counter/components/Counter.js
@@ -1,7 +1,7 @@
-import React, { PropTypes, Component } from 'react'
+import React, { PropTypes } from 'react'
 
-const Counter = ({increment, incrementIfOdd, incrementAsync, decrement, counter}) => {
-    return (
+const Counter = ({ increment, incrementIfOdd, incrementAsync, decrement, counter }) => {
+  return (
       <p>
         Clicked: {counter} times
         {' '}

--- a/examples/counter/components/Counter.js
+++ b/examples/counter/components/Counter.js
@@ -1,8 +1,6 @@
-import React, { Component, PropTypes } from 'react'
+import React, { PropTypes, Component } from 'react'
 
-class Counter extends Component {
-  render() {
-    const { increment, incrementIfOdd, incrementAsync, decrement, counter } = this.props
+const Counter = ({increment, incrementIfOdd, incrementAsync, decrement, counter}) => {
     return (
       <p>
         Clicked: {counter} times
@@ -16,7 +14,6 @@ class Counter extends Component {
         <button onClick={() => incrementAsync()}>Increment async</button>
       </p>
     )
-  }
 }
 
 Counter.propTypes = {

--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -33,6 +33,7 @@
     "mocha": "^2.2.5",
     "node-libs-browser": "^0.5.2",
     "react-addons-test-utils": "^0.14.0",
+    "react-stateless-wrapper": "^1.0.2",
     "react-transform-hmr": "^1.0.0",
     "webpack": "^1.9.11",
     "webpack-dev-middleware": "^1.2.0",

--- a/examples/counter/test/components/Counter.spec.js
+++ b/examples/counter/test/components/Counter.spec.js
@@ -2,6 +2,9 @@ import expect from 'expect'
 import React from 'react'
 import TestUtils from 'react-addons-test-utils'
 import Counter from '../../components/Counter'
+import { wrap } from 'react-stateless-wrapper'
+
+let WrappedComponent = wrap(Counter)
 
 function setup() {
   const actions = {
@@ -10,7 +13,7 @@ function setup() {
     incrementAsync: expect.createSpy(),
     decrement: expect.createSpy()
   }
-  const component = TestUtils.renderIntoDocument(<Counter counter={1} {...actions} />)
+  const component = TestUtils.renderIntoDocument(<WrappedComponent counter={1} {...actions} />)
   return {
     component: component,
     actions: actions,

--- a/examples/real-world/components/List.js
+++ b/examples/real-world/components/List.js
@@ -1,8 +1,8 @@
-import React, { Component, PropTypes } from 'react'
+import React, { PropTypes } from 'react'
 
-function renderLoadMore(props){
-    const { isFetching, onLoadMoreClick } = props
-    return (
+function renderLoadMore(props) {
+  const { isFetching, onLoadMoreClick } = props
+  return (
       <button style={{ fontSize: '150%' }}
               onClick={onLoadMoreClick}
               disabled={isFetching}>
@@ -12,22 +12,22 @@ function renderLoadMore(props){
 }
 
 const  List = (props) =>{
-    const {
-      isFetching, nextPageUrl, pageCount,
-      items, renderItem, loadingLabel
-    } = props
+  const {
+  isFetching, nextPageUrl, pageCount,
+  items, renderItem, loadingLabel
+  } = props
 
-    const isEmpty = items.length === 0
-    if (isEmpty && isFetching) {
-      return <h2><i>{loadingLabel}</i></h2>
-    }
+  const isEmpty = items.length === 0
+  if (isEmpty && isFetching) {
+    return <h2><i>{loadingLabel}</i></h2>
+  }
 
-    const isLastPage = !nextPageUrl
-    if (isEmpty && isLastPage) {
-      return <h1><i>Nothing here!</i></h1>
-    }
+  const isLastPage = !nextPageUrl
+  if (isEmpty && isLastPage) {
+    return <h1><i>Nothing here!</i></h1>
+  }
 
-    return (
+  return (
       <div>
         {items.map(renderItem)}
         {pageCount > 0 && !isLastPage && renderLoadMore(props)}
@@ -51,4 +51,4 @@ List.defaultProps = {
   loadingLabel: 'Loading...'
 }
 
-export default List;
+export default List

--- a/examples/real-world/components/List.js
+++ b/examples/real-world/components/List.js
@@ -1,8 +1,7 @@
 import React, { Component, PropTypes } from 'react'
 
-export default class List extends Component {
-  renderLoadMore() {
-    const { isFetching, onLoadMoreClick } = this.props
+function renderLoadMore(props){
+    const { isFetching, onLoadMoreClick } = props
     return (
       <button style={{ fontSize: '150%' }}
               onClick={onLoadMoreClick}
@@ -10,13 +9,13 @@ export default class List extends Component {
         {isFetching ? 'Loading...' : 'Load More'}
       </button>
     )
-  }
+}
 
-  render() {
+const  List = (props) =>{
     const {
       isFetching, nextPageUrl, pageCount,
       items, renderItem, loadingLabel
-    } = this.props
+    } = props
 
     const isEmpty = items.length === 0
     if (isEmpty && isFetching) {
@@ -31,10 +30,10 @@ export default class List extends Component {
     return (
       <div>
         {items.map(renderItem)}
-        {pageCount > 0 && !isLastPage && this.renderLoadMore()}
+        {pageCount > 0 && !isLastPage && renderLoadMore(props)}
       </div>
     )
-  }
+  
 }
 
 List.propTypes = {
@@ -51,3 +50,5 @@ List.defaultProps = {
   isFetching: true,
   loadingLabel: 'Loading...'
 }
+
+export default List;

--- a/examples/real-world/components/Repo.js
+++ b/examples/real-world/components/Repo.js
@@ -1,11 +1,11 @@
-import React, { Component, PropTypes } from 'react'
+import React, { PropTypes } from 'react'
 import { Link } from 'react-router'
 
 const Repo = (props) =>{
-    const { repo, owner } = props
-    const { login } = owner
-    const { name, description } = repo
-    return (
+  const { repo, owner } = props
+  const { login } = owner
+  const { name, description } = repo
+  return (
       <div className="Repo">
         <h3>
           <Link to={`/${login}/${name}`}>
@@ -34,4 +34,4 @@ Repo.propTypes = {
   }).isRequired
 }
 
-export default Repo;
+export default Repo

--- a/examples/real-world/components/Repo.js
+++ b/examples/real-world/components/Repo.js
@@ -1,13 +1,10 @@
 import React, { Component, PropTypes } from 'react'
 import { Link } from 'react-router'
 
-export default class Repo extends Component {
-
-  render() {
-    const { repo, owner } = this.props
+const Repo = (props) =>{
+    const { repo, owner } = props
     const { login } = owner
     const { name, description } = repo
-
     return (
       <div className="Repo">
         <h3>
@@ -24,7 +21,7 @@ export default class Repo extends Component {
         }
       </div>
     )
-  }
+  
 }
 
 Repo.propTypes = {
@@ -36,3 +33,5 @@ Repo.propTypes = {
     login: PropTypes.string.isRequired
   }).isRequired
 }
+
+export default Repo;

--- a/examples/real-world/components/User.js
+++ b/examples/real-world/components/User.js
@@ -1,9 +1,9 @@
-import React, { Component, PropTypes } from 'react'
+import React, { PropTypes } from 'react'
 import { Link } from 'react-router'
 
 const User = (props) => {
-    const { login, avatarUrl, name } = props.user
-    return (
+  const { login, avatarUrl, name } = props.user
+  return (
       <div className="User">
         <Link to={`/${login}`}>
           <img src={avatarUrl} width="72" height="72" />
@@ -24,4 +24,4 @@ User.propTypes = {
   }).isRequired
 }
 
-export default User;
+export default User

--- a/examples/real-world/components/User.js
+++ b/examples/real-world/components/User.js
@@ -1,10 +1,8 @@
 import React, { Component, PropTypes } from 'react'
 import { Link } from 'react-router'
 
-export default class User extends Component {
-  render() {
-    const { login, avatarUrl, name } = this.props.user
-
+const User = (props) => {
+    const { login, avatarUrl, name } = props.user
     return (
       <div className="User">
         <Link to={`/${login}`}>
@@ -15,7 +13,7 @@ export default class User extends Component {
         </Link>
       </div>
     )
-  }
+  
 }
 
 User.propTypes = {
@@ -25,3 +23,5 @@ User.propTypes = {
     name: PropTypes.string
   }).isRequired
 }
+
+export default User;

--- a/examples/shopping-cart/components/Cart.js
+++ b/examples/shopping-cart/components/Cart.js
@@ -1,19 +1,18 @@
-import React, { Component, PropTypes } from 'react'
+import React, { PropTypes } from 'react'
 import Product from './Product'
 
 const Cart = ({ products, total, onCheckoutClicked }) => {
-    const hasProducts = products.length > 0
-    const nodes = !hasProducts ?
+  const hasProducts = products.length > 0
+  const nodes = !hasProducts ?
       <em>Please add some products to cart.</em> :
-      products.map(product =>
+        products.map(product =>
         <Product
           title={product.title}
           price={product.price}
           quantity={product.quantity}
           key={product.id}/>
     )
-
-    return (
+  return (
       <div>
         <h3>Your Cart</h3>
         <div>{nodes}</div>
@@ -32,4 +31,5 @@ Cart.propTypes = {
   onCheckoutClicked: PropTypes.func
 }
 
-export default Cart;
+export default Cart
+

--- a/examples/shopping-cart/components/Cart.js
+++ b/examples/shopping-cart/components/Cart.js
@@ -1,10 +1,7 @@
 import React, { Component, PropTypes } from 'react'
 import Product from './Product'
 
-export default class Cart extends Component {
-  render() {
-    const { products, total, onCheckoutClicked } = this.props
-
+const Cart = ({ products, total, onCheckoutClicked }) => {
     const hasProducts = products.length > 0
     const nodes = !hasProducts ?
       <em>Please add some products to cart.</em> :
@@ -27,7 +24,6 @@ export default class Cart extends Component {
         </button>
       </div>
     )
-  }
 }
 
 Cart.propTypes = {
@@ -35,3 +31,5 @@ Cart.propTypes = {
   total: PropTypes.string,
   onCheckoutClicked: PropTypes.func
 }
+
+export default Cart;

--- a/examples/shopping-cart/components/Product.js
+++ b/examples/shopping-cart/components/Product.js
@@ -1,10 +1,7 @@
 import React, { Component, PropTypes } from 'react'
 
-export default class Product extends Component {
-  render() {
-    const { price, quantity, title } = this.props
+const Product = ({ price, quantity, title }) => {
     return <div> {title} - &#36;{price} {quantity ? `x ${quantity}` : null} </div>
-  }
 }
 
 Product.propTypes = {
@@ -12,3 +9,5 @@ Product.propTypes = {
   quantity: PropTypes.number,
   title: PropTypes.string
 }
+
+export default Product;

--- a/examples/shopping-cart/components/Product.js
+++ b/examples/shopping-cart/components/Product.js
@@ -1,7 +1,7 @@
-import React, { Component, PropTypes } from 'react'
+import React, { PropTypes } from 'react'
 
 const Product = ({ price, quantity, title }) => {
-    return <div> {title} - &#36;{price} {quantity ? `x ${quantity}` : null} </div>
+  return <div> {title} - &#36;{price} {quantity ? `x ${quantity}` : null} </div>
 }
 
 Product.propTypes = {
@@ -10,4 +10,4 @@ Product.propTypes = {
   title: PropTypes.string
 }
 
-export default Product;
+export default Product

--- a/examples/shopping-cart/components/ProductItem.js
+++ b/examples/shopping-cart/components/ProductItem.js
@@ -1,10 +1,7 @@
 import React, { Component, PropTypes } from 'react'
 import Product from './Product'
 
-export default class ProductItem extends Component {
-  render() {
-    const { product } = this.props
-
+const ProductItem = ({product,onAddToCartClicked}) => {
     return (
       <div
         style={{ marginBottom: 20 }}>
@@ -12,13 +9,12 @@ export default class ProductItem extends Component {
           title={product.title}
           price={product.price} />
         <button
-          onClick={this.props.onAddToCartClicked}
+          onClick={onAddToCartClicked}
           disabled={product.inventory > 0 ? '' : 'disabled'}>
           {product.inventory > 0 ? 'Add to cart' : 'Sold Out'}
         </button>
       </div>
     )
-  }
 }
 
 ProductItem.propTypes = {
@@ -29,3 +25,6 @@ ProductItem.propTypes = {
   }).isRequired,
   onAddToCartClicked: PropTypes.func.isRequired
 }
+
+
+export default ProductItem;

--- a/examples/shopping-cart/components/ProductItem.js
+++ b/examples/shopping-cart/components/ProductItem.js
@@ -1,8 +1,8 @@
-import React, { Component, PropTypes } from 'react'
+import React, { PropTypes } from 'react'
 import Product from './Product'
 
-const ProductItem = ({product,onAddToCartClicked}) => {
-    return (
+const ProductItem = ({ product,onAddToCartClicked }) => {
+  return (
       <div
         style={{ marginBottom: 20 }}>
         <Product
@@ -27,4 +27,4 @@ ProductItem.propTypes = {
 }
 
 
-export default ProductItem;
+export default ProductItem

--- a/examples/shopping-cart/components/ProductsList.js
+++ b/examples/shopping-cart/components/ProductsList.js
@@ -1,17 +1,17 @@
 import React, { Component, PropTypes } from 'react'
 
-export default class ProductsList extends Component {
-  render() {
+const ProductsList = (props) =>{
     return (
       <div>
-        <h3>{this.props.title}</h3>
-        <div>{this.props.children}</div>
+        <h3>{props.title}</h3>
+        <div>{props.children}</div>
       </div>
     )
-  }
 }
 
 ProductsList.propTypes = {
   children: PropTypes.node,
   title: PropTypes.string.isRequired
 }
+
+export default ProductsList;

--- a/examples/shopping-cart/components/ProductsList.js
+++ b/examples/shopping-cart/components/ProductsList.js
@@ -1,7 +1,7 @@
-import React, { Component, PropTypes } from 'react'
+import React, { PropTypes } from 'react'
 
 const ProductsList = (props) =>{
-    return (
+  return (
       <div>
         <h3>{props.title}</h3>
         <div>{props.children}</div>
@@ -14,4 +14,4 @@ ProductsList.propTypes = {
   title: PropTypes.string.isRequired
 }
 
-export default ProductsList;
+export default ProductsList


### PR DESCRIPTION
I have changed some examples folder to default stateless components to more cleaner new syntax introduced in react 0.14 , If you like you can merge the changes.