### PR TITLE
Fix babel config inheritance

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
   "stage": 0,
-  "loose": "all"
+  "loose": "all",
+  "breakConfig": true
 }


### PR DESCRIPTION
If I have ``` babel 6 ``` in globally, and this project is run in ```babel 5```, in project the config file ```.babelrc``` will  inheritance the globally ``` .babelrc ```file, then the project can't run.
[same issue inredux-tutorial ](https://github.com/happypoulp/redux-tutorial/issues/88)
[issue in stackoverflow](http://stackoverflow.com/questions/32540598/disable-babelrc-inheritance)