### PR TITLE
Accept multiple params in middleware API dispatch

### DIFF
--- a/src/utils/applyMiddleware.js
+++ b/src/utils/applyMiddleware.js
@@ -24,7 +24,7 @@ export default function applyMiddleware(...middlewares) {
 
     var middlewareAPI = {
       getState: store.getState,
-      dispatch: (action) => dispatch(action)
+      dispatch: (...params) => dispatch(...params)
     }
     chain = middlewares.map(middleware => middleware(middlewareAPI))
     dispatch = compose(...chain)(store.dispatch)


### PR DESCRIPTION
The current middleware API `dispatch` function only accepts one parameter -- the action. I am using a custom middleware in my application that converts a parameter list to an action on the dispatch function, so I need the dispatch function on the middleware API to pass that parameter list along.

For reference, here is the custom middleware I am using:
```js
function typeMiddleware() {
  return next => (type, ...payloads) => {
    if (!payloads.every(p => typeof p === 'object')) {
      throw new TypeError('payload must be an object');
    }

    if (typeof type === 'string') {
      type = { type };
    }
    let payload = Object.assign(type, ...payloads);
    return next(payload);
  };
}
```