### PR TITLE
Fixed bad key

### DIFF
--- a/docs/basics/UsageWithReact.md
+++ b/docs/basics/UsageWithReact.md
@@ -154,7 +154,7 @@ export default class TodoList extends Component {
       <ul>
         {this.props.todos.map((todo, index) =>
           <Todo {...todo}
-                key={index}
+                key={index + todo.text}
                 onClick={() => this.props.onTodoClick(index)} />
         )}
       </ul>


### PR DESCRIPTION
Never use indices for keys in React. React depends on fully unique values for keys, so when items are added or removed, it can accurately shift them around in the DOM in the most efficient manner. The only instance where the user would see things go wrong is if you were using `ReactCSSTransitionGroup` to make items fade in and out as they appear/disappear. If you were to use the index as the key, you'd see some wonky things happen with the animation.