### PR TITLE
Examples: todomvc: Removed precondition to clear completed todo's

### DIFF
--- a/examples/todomvc/components/MainSection.js
+++ b/examples/todomvc/components/MainSection.js
@@ -16,10 +16,7 @@ class MainSection extends Component {
   }
 
   handleClearCompleted() {
-    const atLeastOneCompleted = this.props.todos.some(todo => todo.completed)
-    if (atLeastOneCompleted) {
-      this.props.actions.clearCompleted()
-    }
+    this.props.actions.clearCompleted()
   }
 
   handleShow(filter) {

--- a/examples/todomvc/test/components/MainSection.spec.js
+++ b/examples/todomvc/test/components/MainSection.spec.js
@@ -102,21 +102,6 @@ describe('components', () => {
         footer.props.onClearCompleted()
         expect(props.actions.clearCompleted).toHaveBeenCalled()
       })
-
-      it('onClearCompleted shouldnt call clearCompleted if no todos completed', () => {
-        const { output, props } = setup({ 
-          todos: [
-            {
-              text: 'Use Redux',
-              completed: false,
-              id: 0
-            }
-          ]
-        })
-        const [ , , footer ] = output.props.children
-        footer.props.onClearCompleted()
-        expect(props.actions.clearCompleted.calls.length).toBe(0)
-      })
     })
 
     describe('todo list', () => {


### PR DESCRIPTION
Perhaps this is an optimization to prevent against an unneeded re-render. However this may be adding more confusion to the example than benefit. Am I wrong by removing this?