### PR TITLE
Update ServerRendering.md

### DIFF
--- a/docs/recipes/ServerRendering.md
+++ b/docs/recipes/ServerRendering.md
@@ -148,7 +148,7 @@ render(
   <Provider store={store}>
     <App />
   </Provider>,
-  document.getElementById('root')
+  document.getElementById('app')
 )
 ```
 


### PR DESCRIPTION
On the Server Rendering Redux recipe, the `<div id="root">` and `document.getElementById('app')` do not match.

Screenshots:

![screen shot 2016-01-22 at 10 56 34 am](https://cloud.githubusercontent.com/assets/6934989/12515680/8110cc48-c0f7-11e5-93c4-85b033aa55f4.png)
![screen shot 2016-01-22 at 10 56 48 am](https://cloud.githubusercontent.com/assets/6934989/12515682/81c1b724-c0f7-11e5-9af6-85d25f7ece7b.png)

**Fix**
Use `app` for both id's.
