### PR TITLE
Update applyMiddleware enhancer to use new createStore signature

### DIFF
--- a/src/applyMiddleware.js
+++ b/src/applyMiddleware.js
@@ -17,8 +17,8 @@ import compose from './compose'
  * @returns {Function} A store enhancer applying the middleware.
  */
 export default function applyMiddleware(...middlewares) {
-  return (createStore) => (reducer, initialState) => {
-    var store = createStore(reducer, initialState)
+  return (createStore) => (reducer, initialState, enhancer) => {
+    var store = createStore(reducer, initialState, enhancer)
     var dispatch = store.dispatch
     var chain = []
 


### PR DESCRIPTION
3.1 changed the signature of `createStore()`. This isn't considered a breaking change because existing enhancers will continue to work; however, going forward, it should be expected that a store enhancer returns a `createStore` function with the same signature as its input.

See https://twitter.com/acdlite/status/692772885186764802 for context

Still needs tests :)