### PR TITLE
replaceReducer() should throw if argument is not a function fix #1318

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -159,8 +159,12 @@ export default function createStore(reducer, initialState, enhancer) {
    * @returns {void}
    */
   function replaceReducer(nextReducer) {
-    currentReducer = nextReducer
-    dispatch({ type: ActionTypes.INIT })
+    if (typeof nextReducer === 'function') {
+      currentReducer = nextReducer
+      dispatch({ type: ActionTypes.INIT })
+    } else {
+      throw new Error('Expected the nextReducer to be a function.')
+    }
   }
 
   // When a store is created, an "INIT" action is dispatched so that every

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -159,11 +159,11 @@ export default function createStore(reducer, initialState, enhancer) {
    * @returns {void}
    */
   function replaceReducer(nextReducer) {
-    if (typeof nextReducer === 'function') {
+    if (typeof nextReducer !== 'function') {
+      throw new Error('Expected the nextReducer to be a function.')
+    } else {
       currentReducer = nextReducer
       dispatch({ type: ActionTypes.INIT })
-    } else {
-      throw new Error('Expected the nextReducer to be a function.')
     }
   }
 


### PR DESCRIPTION
Fix for: #1318 