### PR TITLE
replaceReducer() should throw if argument is not a function

### DIFF
--- a/src/createStore.js
+++ b/src/createStore.js
@@ -159,6 +159,10 @@ export default function createStore(reducer, initialState, enhancer) {
    * @returns {void}
    */
   function replaceReducer(nextReducer) {
+    if (typeof nextReducer !== 'function') {
+      throw new Error('Expected the nextReducer to be a function.')
+    }
+
     currentReducer = nextReducer
     dispatch({ type: ActionTypes.INIT })
   }

--- a/test/createStore.spec.js
+++ b/test/createStore.spec.js
@@ -536,4 +536,16 @@ describe('createStore', () => {
       createStore(reducers.todos, {})
     ).toNotThrow()
   })
+
+  it('throws if nextReducer is not a function', () => {
+    const store = createStore(reducers.todos)
+
+    expect(() =>
+      store.replaceReducer()
+    ).toThrow('Expected the nextReducer to be a function.')
+
+    expect(() =>
+      store.replaceReducer(() => {})
+    ).toNotThrow()
+  })
 })


### PR DESCRIPTION
Fixes for #1318 