### PR TITLE
Drop broken jsnext:main

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "3.1.5",
   "description": "Predictable state container for JavaScript apps",
   "main": "lib/index.js",
-  "jsnext:main": "src/index.js",
   "files": [
     "dist",
     "lib",


### PR DESCRIPTION
Closes https://github.com/rackt/redux/issues/1042

Per https://github.com/rackt/redux/issues/1042#issuecomment-164312922, it looks like there's not much benefit in adding a proper ES2015 module build, and the current `jsnext:main` pointing at untranspiled code doesn't accomplish anything other than breaking rollup users.

As I recall, there are remain other reasons for continuing to distribute `src/` (Flow-related?), so I didn't drop that from `files`.