### PR TITLE
[RFC] Cache bound action creators with WeakMap

### DIFF
--- a/test/bindActionCreators.spec.js
+++ b/test/bindActionCreators.spec.js
@@ -61,6 +61,48 @@ describe('bindActionCreators', () => {
     ])
   })
 
+  it('caches bound action creator', () => {
+    expect(
+      bindActionCreators(actionCreators.addTodo, store.dispatch)
+    ).toBe(
+      bindActionCreators(actionCreators.addTodo, store.dispatch)
+    )
+
+    const store2 = createStore(todos)
+    expect(
+      bindActionCreators(actionCreators.addTodo, store2.dispatch)
+    ).toEqual(
+      bindActionCreators(actionCreators.addTodo, store2.dispatch)
+    )
+
+    expect(
+      bindActionCreators(actionCreators.addTodo, store.dispatch)
+    ).toEqual(
+      bindActionCreators(actionCreators.addTodo, store.dispatch)
+    )
+  })
+
+  it('caches bound action creators', () => {
+    expect(
+      bindActionCreators(actionCreators, store.dispatch)
+    ).toEqual(
+      bindActionCreators(actionCreatorFunctions, store.dispatch)
+    )
+
+    const store2 = createStore(todos)
+    expect(
+      bindActionCreators(actionCreators, store2.dispatch)
+    ).toEqual(
+      bindActionCreators(actionCreatorFunctions, store2.dispatch)
+    )
+
+    expect(
+      bindActionCreators(actionCreators, store.dispatch)
+    ).toEqual(
+      bindActionCreators(actionCreatorFunctions, store.dispatch)
+    )
+  })
+
   it('throws for an undefined actionCreator', () => {
     expect(() => {
       bindActionCreators(undefined, store.dispatch)


### PR DESCRIPTION
This is an experimental optimization. I do see some speedups on Chrome and Firefox when rendering many components (which happen to call `bindActionCreators`) but I'm not sure whether this optimization is worth it, and whether it has downsides on other browsers/engines. **I’m not very knowledgeable in JS performance so I hope somebody else can share their perspective on this.**

In my testing this improves performance when you create many connected components of the same type. For example, when a list view adds many rows. It is wasteful to bind the same action creator to the same `dispatch` function over and over again.

Here, we use `WeakMap` if available to cache the bound action creators. Using `WeakMap` allows us to prevent leaks on the server where you'd have a separate store instance on every request.

Does this make sense?