### PR TITLE
Lowercase private actions

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -1,4 +1,4 @@
-import { ActionTypes } from './createStore'
+import { actionTypes } from './createStore'
 import isPlainObject from 'lodash/isPlainObject'
 import warning from './utils/warning'
 
@@ -14,7 +14,7 @@ function getUndefinedStateErrorMessage(key, action) {
 
 function getUnexpectedStateShapeWarningMessage(inputState, reducers, action) {
   var reducerKeys = Object.keys(reducers)
-  var argumentName = action && action.type === ActionTypes.INIT ?
+  var argumentName = action && action.type === actionTypes.INIT ?
     'initialState argument passed to createStore' :
     'previous state received by the reducer'
 
@@ -49,7 +49,7 @@ function getUnexpectedStateShapeWarningMessage(inputState, reducers, action) {
 function assertReducerSanity(reducers) {
   Object.keys(reducers).forEach(key => {
     var reducer = reducers[key]
-    var initialState = reducer(undefined, { type: ActionTypes.INIT })
+    var initialState = reducer(undefined, { type: actionTypes.INIT })
 
     if (typeof initialState === 'undefined') {
       throw new Error(
@@ -64,7 +64,7 @@ function assertReducerSanity(reducers) {
     if (typeof reducer(undefined, { type }) === 'undefined') {
       throw new Error(
         `Reducer "${key}" returned undefined when probed with a random type. ` +
-        `Don't try to handle ${ActionTypes.INIT} or other actions in "redux/*" ` +
+        `Don't try to handle ${actionTypes.INIT} or other actions in "redux/*" ` +
         `namespace. They are considered private. Instead, you must return the ` +
         `current state for any unknown actions, unless it is undefined, ` +
         `in which case you must return the initial state, regardless of the ` +

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -6,7 +6,7 @@ import isPlainObject from 'lodash/isPlainObject'
  * If the current state is undefined, you must return the initial state.
  * Do not reference these action types directly in your code.
  */
-export var ActionTypes = {
+export var actionTypes = {
   INIT: '@@redux/INIT'
 }
 
@@ -195,13 +195,13 @@ export default function createStore(reducer, initialState, enhancer) {
     }
 
     currentReducer = nextReducer
-    dispatch({ type: ActionTypes.INIT })
+    dispatch({ type: actionTypes.INIT })
   }
 
   // When a store is created, an "INIT" action is dispatched so that every
   // reducer returns their initial state. This effectively populates
   // the initial state tree.
-  dispatch({ type: ActionTypes.INIT })
+  dispatch({ type: actionTypes.INIT })
 
   return {
     dispatch,

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -1,6 +1,6 @@
 import expect from 'expect'
 import { combineReducers } from '../src'
-import createStore, { ActionTypes } from '../src/createStore'
+import createStore, { actionTypes } from '../src/createStore'
 
 describe('Utils', () => {
   describe('combineReducers', () => {
@@ -160,7 +160,7 @@ describe('Utils', () => {
             case 'decrement':
               return state - 1
             // Never do this in your code:
-            case ActionTypes.INIT:
+            case actionTypes.INIT:
               return 0
             default:
               return undefined


### PR DESCRIPTION
A popular convention in JavaScript is to only capitalize constructor functions or ES6 classes.

The `actionTypes` variable is a **bare object** — and should therefore be lowercased.

In some cases this might be acceptable

```js
import * as ActionTypes from '../actions'
```