### PR TITLE
Update ServerRendering.md

### DIFF
--- a/docs/recipes/ServerRendering.md
+++ b/docs/recipes/ServerRendering.md
@@ -179,7 +179,7 @@ import { renderToString } from 'react-dom/server'
 function handleRender(req, res) {
   // Read the counter from the request, if provided
   const params = qs.parse(req.query)
-  const counter = parseInt(params.counter,10) || 0
+  const counter = parseInt(params.counter, 10) || 0
 
   // Compile an initial state
   let initialState = { counter }
@@ -242,7 +242,7 @@ function handleRender(req, res) {
   fetchCounter(apiResult => {
     // Read the counter from the request, if provided
     const params = qs.parse(req.query)
-    const counter = parseInt(params.counter,10) || apiResult || 0
+    const counter = parseInt(params.counter, 10) || apiResult || 0
 
     // Compile an initial state
     let initialState = { counter }

--- a/docs/recipes/ServerRendering.md
+++ b/docs/recipes/ServerRendering.md
@@ -179,7 +179,7 @@ import { renderToString } from 'react-dom/server'
 function handleRender(req, res) {
   // Read the counter from the request, if provided
   const params = qs.parse(req.query)
-  const counter = parseInt(params.counter) || 0
+  const counter = parseInt(params.counter,10) || 0
 
   // Compile an initial state
   let initialState = { counter }
@@ -242,7 +242,7 @@ function handleRender(req, res) {
   fetchCounter(apiResult => {
     // Read the counter from the request, if provided
     const params = qs.parse(req.query)
-    const counter = parseInt(params.counter) || apiResult || 0
+    const counter = parseInt(params.counter,10) || apiResult || 0
 
     // Compile an initial state
     let initialState = { counter }


### PR DESCRIPTION
Always use radix when using parseInt. Other options are Number or isNaN, or maybe even better, the ES6 specific Number.isNaN() - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN.