### PR TITLE
Reword error message for 'reducer returned undefined'

### DIFF
--- a/src/combineReducers.js
+++ b/src/combineReducers.js
@@ -7,7 +7,7 @@ function getUndefinedStateErrorMessage(key, action) {
   var actionName = actionType && `"${actionType.toString()}"` || 'an action'
 
   return (
-    `Reducer "${key}" returned undefined handling ${actionName}. ` +
+    `Given action ${actionName}, reducer "${key}" returned undefined. ` +
     `To ignore an action, you must explicitly return the previous state.`
   )
 }

--- a/test/combineReducers.spec.js
+++ b/test/combineReducers.spec.js
@@ -52,7 +52,7 @@ describe('Utils', () => {
       expect(
         () => reducer({ counter: 0 }, { type: 'whatever' })
       ).toThrow(
-      /"counter".*"whatever"/
+      /"whatever".*"counter"/
       )
       expect(
         () => reducer({ counter: 0 }, null)


### PR DESCRIPTION
Minor rewording of error message to address issue #1375.

Old message:
` Uncaught Error: Reducer "nameReducer" returned undefined handling "SET_NAME". To ignore an action, you must explicitly return the previous state.`

New message:
`Uncaught Error: Given action "SET_NAME", reducer "nameReducer" returned undefined. To ignore an action, you must explicitly return the previous state.`

